### PR TITLE
⬆️ Update to Sphinx-Needs 6

### DIFF
--- a/docs/ubproject.toml
+++ b/docs/ubproject.toml
@@ -69,7 +69,7 @@ id_regex = "[A-Z_]{3,10}(_[\\d]{1,3})*"
 # Activates variants handling for these options only.
 # All other options get not checked, to save some build time, as these checks are quite time consuming.
 # see https://sphinx-needs.readthedocs.io/en/latest/configuration.html#needs-variant-options
-variant_options = ["author", "status"]
+variant_options = ["status"]
 
 # allowed values for need status core field
 # see https://sphinx-needs.readthedocs.io/en/latest/configuration.html#needs-statuses

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,11 +7,11 @@ authors = [
 ]
 dependencies = [
     "sphinx[test]>=8.2.3",
-    "sphinx-needs[plotting] @ git+https://github.com/useblocks/sphinx-needs.git@02eb6e771a6cc39cc8875c9a77520c02135cc084",
+    "sphinx-needs[plotting]==6.0.1",
     "sphinxcontrib-plantuml>=0.30",
     "sphinx-design>=0.6.1",
     "sphinx-simplepdf>=1.6.0",
-    "sphinx-test-reports @ git+https://github.com/useblocks/sphinx-test-reports.git@23a1f6b9cd1454e6637b18945a7c55f49ed8d283",
+    "sphinx-test-reports @ git+https://github.com/useblocks/sphinx-test-reports.git@7a12d1c00ad051f67a5b0cdedb82c25a012eefdd",
     "furo>=2024.8.6",
     "sphinx-preview>=0.1.2",
     "sphinx-immaterial>=0.13.6",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,11 +7,11 @@ authors = [
 ]
 dependencies = [
     "sphinx[test]>=8.2.3",
-    "sphinx-needs[plotting]~=5.1.0",
+    "sphinx-needs[plotting] @ git+https://github.com/useblocks/sphinx-needs.git@02eb6e771a6cc39cc8875c9a77520c02135cc084",
     "sphinxcontrib-plantuml>=0.30",
     "sphinx-design>=0.6.1",
     "sphinx-simplepdf>=1.6.0",
-    "sphinx-test-reports>=1.2.0",
+    "sphinx-test-reports @ git+https://github.com/useblocks/sphinx-test-reports.git@23a1f6b9cd1454e6637b18945a7c55f49ed8d283",
     "furo>=2024.8.6",
     "sphinx-preview>=0.1.2",
     "sphinx-immaterial>=0.13.6",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,11 +7,11 @@ authors = [
 ]
 dependencies = [
     "sphinx[test]>=8.2.3",
-    "sphinx-needs[plotting]==6.0.1",
+    "sphinx-needs[plotting]==6.0.1",  # pin as RTD consumes this file, not uv.lock
     "sphinxcontrib-plantuml>=0.30",
     "sphinx-design>=0.6.1",
     "sphinx-simplepdf>=1.6.0",
-    "sphinx-test-reports @ git+https://github.com/useblocks/sphinx-test-reports.git@7a12d1c00ad051f67a5b0cdedb82c25a012eefdd",
+    "sphinx-test-reports==1.3.1",  # pin as RTD consumes this file, not uv.lock
     "furo>=2024.8.6",
     "sphinx-preview>=0.1.2",
     "sphinx-immaterial>=0.13.6",

--- a/uv.lock
+++ b/uv.lock
@@ -42,6 +42,19 @@ wheels = [
 ]
 
 [[package]]
+name = "arrow"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+    { name = "types-python-dateutil" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2e/00/0f6e8fcdb23ea632c866620cc872729ff43ed91d284c866b515c6342b173/arrow-1.3.0.tar.gz", hash = "sha256:d4540617648cb5f895730f1ad8c82a65f2dad0166f57b75f3ca54759c4d67a85", size = 131960, upload-time = "2023-09-30T22:11:18.25Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f8/ed/e97229a566617f2ae958a6b13e7cc0f585470eac730a73e9e82c32a3cdd2/arrow-1.3.0-py3-none-any.whl", hash = "sha256:c728b120ebc00eb84e01882a6f5e7927a53960aa990ce7dd2b10f39005a67f80", size = 66419, upload-time = "2023-09-30T22:11:16.072Z" },
+]
+
+[[package]]
 name = "attrs"
 version = "25.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -447,6 +460,15 @@ woff = [
 ]
 
 [[package]]
+name = "fqdn"
+version = "1.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/30/3e/a80a8c077fd798951169626cde3e239adeba7dab75deb3555716415bd9b0/fqdn-1.5.1.tar.gz", hash = "sha256:105ed3677e767fb5ca086a0c1f4bb66ebc3c100be518f0e0d755d9eae164d89f", size = 6015, upload-time = "2021-03-11T07:16:29.08Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cf/58/8acf1b3e91c58313ce5cb67df61001fc9dcd21be4fadb76c1a2d540e09ed/fqdn-1.5.1-py3-none-any.whl", hash = "sha256:3a179af3761e4df6eb2e026ff9e1a3033d3587bf980a0b1b2e1e5d08d7358014", size = 9121, upload-time = "2021-03-11T07:16:28.351Z" },
+]
+
+[[package]]
 name = "furo"
 version = "2025.9.25"
 source = { registry = "https://pypi.org/simple" }
@@ -490,6 +512,18 @@ wheels = [
 ]
 
 [[package]]
+name = "isoduration"
+version = "20.11.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "arrow" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7c/1a/3c8edc664e06e6bd06cce40c6b22da5f1429aa4224d0c590f3be21c91ead/isoduration-20.11.0.tar.gz", hash = "sha256:ac2f9015137935279eac671f94f89eb00584f940f5dc49462a0c4ee692ba1bd9", size = 11649, upload-time = "2020-11-01T11:00:00.312Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/55/e5326141505c5d5e34c5e0935d2908a74e4561eca44108fbfb9c13d2911a/isoduration-20.11.0-py3-none-any.whl", hash = "sha256:b2904c2a4228c3d44f409c8ae8e2370eb21a26f7ac2ec5446df141dde3452042", size = 11321, upload-time = "2020-11-01T10:59:58.02Z" },
+]
+
+[[package]]
 name = "jinja2"
 version = "3.1.6"
 source = { registry = "https://pypi.org/simple" }
@@ -499,6 +533,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "jsonpointer"
+version = "3.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6a/0a/eebeb1fa92507ea94016a2a790b93c2ae41a7e18778f85471dc54475ed25/jsonpointer-3.0.0.tar.gz", hash = "sha256:2b2d729f2091522d61c3b31f82e11870f60b68f43fbc705cb76bf4b832af59ef", size = 9114, upload-time = "2024-06-10T19:24:42.462Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/92/5e77f98553e9e75130c78900d000368476aed74276eb8ae8796f65f00918/jsonpointer-3.0.0-py2.py3-none-any.whl", hash = "sha256:13e088adc14fca8b6aa8177c044e12701e6ad4b28ff10e65f2267a90109c9942", size = 7595, upload-time = "2024-06-10T19:24:40.698Z" },
 ]
 
 [[package]]
@@ -514,6 +557,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/74/69/f7185de793a29082a9f3c7728268ffb31cb5095131a9c139a74078e27336/jsonschema-4.25.1.tar.gz", hash = "sha256:e4a9655ce0da0c0b67a085847e00a3a51449e1157f4f75e9fb5aa545e122eb85", size = 357342, upload-time = "2025-08-18T17:03:50.038Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/bf/9c/8c95d856233c1f82500c2450b8c68576b4cf1c871db3afac5c34ff84e6fd/jsonschema-4.25.1-py3-none-any.whl", hash = "sha256:3fba0169e345c7175110351d456342c364814cfcf3b964ba4587f22915230a63", size = 90040, upload-time = "2025-08-18T17:03:48.373Z" },
+]
+
+[package.optional-dependencies]
+format = [
+    { name = "fqdn" },
+    { name = "idna" },
+    { name = "isoduration" },
+    { name = "jsonpointer" },
+    { name = "rfc3339-validator" },
+    { name = "rfc3987" },
+    { name = "uri-template" },
+    { name = "webcolors" },
 ]
 
 [[package]]
@@ -1176,6 +1231,27 @@ wheels = [
 ]
 
 [[package]]
+name = "rfc3339-validator"
+version = "0.1.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/28/ea/a9387748e2d111c3c2b275ba970b735e04e15cdb1eb30693b6b5708c4dbd/rfc3339_validator-0.1.4.tar.gz", hash = "sha256:138a2abdf93304ad60530167e51d2dfb9549521a836871b88d7f4695d0022f6b", size = 5513, upload-time = "2021-05-12T16:37:54.178Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/44/4e421b96b67b2daff264473f7465db72fbdf36a07e05494f50300cc7b0c6/rfc3339_validator-0.1.4-py2.py3-none-any.whl", hash = "sha256:24f6ec1eda14ef823da9e36ec7113124b39c04d50a4d3d3a3c2859577e7791fa", size = 3490, upload-time = "2021-05-12T16:37:52.536Z" },
+]
+
+[[package]]
+name = "rfc3987"
+version = "1.3.8"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/14/bb/f1395c4b62f251a1cb503ff884500ebd248eed593f41b469f89caa3547bd/rfc3987-1.3.8.tar.gz", hash = "sha256:d3c4d257a560d544e9826b38bc81db676890c79ab9d7ac92b39c7a253d5ca733", size = 20700, upload-time = "2018-07-29T17:23:47.954Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/65/d4/f7407c3d15d5ac779c3dd34fbbc6ea2090f77bd7dd12f207ccf881551208/rfc3987-1.3.8-py2.py3-none-any.whl", hash = "sha256:10702b1e51e5658843460b189b185c0366d2cf4cff716f13111b0ea9fd2dce53", size = 13377, upload-time = "2018-07-29T17:23:45.313Z" },
+]
+
+[[package]]
 name = "roman-numerals-py"
 version = "3.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1394,19 +1470,17 @@ wheels = [
 
 [[package]]
 name = "sphinx-needs"
-version = "5.1.0"
-source = { registry = "https://pypi.org/simple" }
+version = "6.0.0"
+source = { git = "https://github.com/useblocks/sphinx-needs.git?rev=02eb6e771a6cc39cc8875c9a77520c02135cc084#02eb6e771a6cc39cc8875c9a77520c02135cc084" }
 dependencies = [
-    { name = "jsonschema" },
+    { name = "jsonschema", extra = ["format"] },
     { name = "requests" },
     { name = "requests-file" },
     { name = "sphinx" },
     { name = "sphinx-data-viewer" },
     { name = "sphinxcontrib-jquery" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/14/cc/6ec2b659b9b7f453cb5c5bd70efef21d083bee7f68525ecf5a1462d540ff/sphinx_needs-5.1.0.tar.gz", hash = "sha256:23a0ca1dfe733a0a58e884b59ce53a8b63a530f0ac87ae5ab0d40f05f853fbe7", size = 27276848, upload-time = "2025-03-06T15:25:34.315Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/33/51/76e0975800ced3179936ae9544a9c2dd5ddddc70dfef6668f9f22f8b87bf/sphinx_needs-5.1.0-py3-none-any.whl", hash = "sha256:7adf3763478e91171146918d8af4a22aa0fc062a73856f1ebeb6822a62cbe215", size = 2635665, upload-time = "2025-03-06T15:25:31.166Z" },
+    { name = "typeguard" },
+    { name = "typing-extensions" },
 ]
 
 [package.optional-dependencies]
@@ -1436,10 +1510,10 @@ requires-dist = [
     { name = "sphinx", extras = ["test"], specifier = ">=8.2.3" },
     { name = "sphinx-design", specifier = ">=0.6.1" },
     { name = "sphinx-immaterial", specifier = ">=0.13.6" },
-    { name = "sphinx-needs", extras = ["plotting"], specifier = "~=5.1.0" },
+    { name = "sphinx-needs", extras = ["plotting"], git = "https://github.com/useblocks/sphinx-needs.git?rev=02eb6e771a6cc39cc8875c9a77520c02135cc084" },
     { name = "sphinx-preview", specifier = ">=0.1.2" },
     { name = "sphinx-simplepdf", specifier = ">=1.6.0" },
-    { name = "sphinx-test-reports", specifier = ">=1.2.0" },
+    { name = "sphinx-test-reports", git = "https://github.com/useblocks/sphinx-test-reports.git?rev=23a1f6b9cd1454e6637b18945a7c55f49ed8d283" },
     { name = "sphinxcontrib-plantuml", specifier = ">=0.30" },
 ]
 
@@ -1470,15 +1544,11 @@ wheels = [
 [[package]]
 name = "sphinx-test-reports"
 version = "1.3.0"
-source = { registry = "https://pypi.org/simple" }
+source = { git = "https://github.com/useblocks/sphinx-test-reports.git?rev=23a1f6b9cd1454e6637b18945a7c55f49ed8d283#23a1f6b9cd1454e6637b18945a7c55f49ed8d283" }
 dependencies = [
     { name = "lxml" },
     { name = "sphinx" },
     { name = "sphinx-needs" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/9d/25/6daa4c5fdcc7b04b38f78e37179258162cec42e9530eaf2389239c485daa/sphinx_test_reports-1.3.0.tar.gz", hash = "sha256:efab490e12cf317e672e2124c248a16067e6aa792efeabb92ead38ca2734be5c", size = 18136, upload-time = "2025-09-28T17:09:59.945Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/52/10/57999f73834a9c6f373225d67648f00f943541c1e90bbcb808097b8e9c91/sphinx_test_reports-1.3.0-py3-none-any.whl", hash = "sha256:4b83f4663832864888d5e42841530c96af57a7524bac2db0baa69b18a6b43d8f", size = 25318, upload-time = "2025-09-28T17:09:58.472Z" },
 ]
 
 [[package]]
@@ -1581,6 +1651,27 @@ wheels = [
 ]
 
 [[package]]
+name = "typeguard"
+version = "4.4.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c7/68/71c1a15b5f65f40e91b65da23b8224dad41349894535a97f63a52e462196/typeguard-4.4.4.tar.gz", hash = "sha256:3a7fd2dffb705d4d0efaed4306a704c89b9dee850b688f060a8b1615a79e5f74", size = 75203, upload-time = "2025-06-18T09:56:07.624Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1b/a9/e3aee762739c1d7528da1c3e06d518503f8b6c439c35549b53735ba52ead/typeguard-4.4.4-py3-none-any.whl", hash = "sha256:b5f562281b6bfa1f5492470464730ef001646128b180769880468bd84b68b09e", size = 34874, upload-time = "2025-06-18T09:56:05.999Z" },
+]
+
+[[package]]
+name = "types-python-dateutil"
+version = "2.9.0.20250822"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0c/0a/775f8551665992204c756be326f3575abba58c4a3a52eef9909ef4536428/types_python_dateutil-2.9.0.20250822.tar.gz", hash = "sha256:84c92c34bd8e68b117bff742bc00b692a1e8531262d4507b33afcc9f7716cd53", size = 16084, upload-time = "2025-08-22T03:02:00.613Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/d9/a29dfa84363e88b053bf85a8b7f212a04f0d7343a4d24933baa45c06e08b/types_python_dateutil-2.9.0.20250822-py3-none-any.whl", hash = "sha256:849d52b737e10a6dc6621d2bd7940ec7c65fcb69e6aa2882acf4e56b2b508ddc", size = 17892, upload-time = "2025-08-22T03:01:59.436Z" },
+]
+
+[[package]]
 name = "typing-extensions"
 version = "4.15.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1599,6 +1690,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "uri-template"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/31/c7/0336f2bd0bcbada6ccef7aaa25e443c118a704f828a0620c6fa0207c1b64/uri-template-1.3.0.tar.gz", hash = "sha256:0e00f8eb65e18c7de20d595a14336e9f337ead580c70934141624b6d1ffdacc7", size = 21678, upload-time = "2023-06-21T01:49:05.374Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/00/3fca040d7cf8a32776d3d81a00c8ee7457e00f80c649f1e4a863c8321ae9/uri_template-1.3.0-py3-none-any.whl", hash = "sha256:a44a133ea12d44a0c0f06d7d42a52d71282e77e2f937d8abd5655b8d56fc1363", size = 11140, upload-time = "2023-06-21T01:49:03.467Z" },
 ]
 
 [[package]]
@@ -1627,6 +1727,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/32/99/480b5430b7eb0916e7d5df1bee7d9508b28b48fee28da894d0a050e0e930/weasyprint-66.0.tar.gz", hash = "sha256:da71dc87dc129ac9cffdc65e5477e90365ab9dbae45c744014ec1d06303dde40", size = 504224, upload-time = "2025-07-24T11:44:42.771Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0f/d1/c5d9b341bf3d556c1e4c6566b3efdda0b1bb175510aa7b09dd3eee246923/weasyprint-66.0-py3-none-any.whl", hash = "sha256:82b0783b726fcd318e2c977dcdddca76515b30044bc7a830cc4fbe717582a6d0", size = 301965, upload-time = "2025-07-24T11:44:40.968Z" },
+]
+
+[[package]]
+name = "webcolors"
+version = "24.11.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/29/061ec845fb58521848f3739e466efd8250b4b7b98c1b6c5bf4d40b419b7e/webcolors-24.11.1.tar.gz", hash = "sha256:ecb3d768f32202af770477b8b65f318fa4f566c22948673a977b00d589dd80f6", size = 45064, upload-time = "2024-11-11T07:43:24.224Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/60/e8/c0e05e4684d13459f93d312077a9a2efbe04d59c393bc2b8802248c908d4/webcolors-24.11.1-py3-none-any.whl", hash = "sha256:515291393b4cdf0eb19c155749a096f779f7d909f7cceea072791cb9095b92e9", size = 14934, upload-time = "2024-11-11T07:43:22.529Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -1470,8 +1470,8 @@ wheels = [
 
 [[package]]
 name = "sphinx-needs"
-version = "6.0.0"
-source = { git = "https://github.com/useblocks/sphinx-needs.git?rev=02eb6e771a6cc39cc8875c9a77520c02135cc084#02eb6e771a6cc39cc8875c9a77520c02135cc084" }
+version = "6.0.1"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jsonschema", extra = ["format"] },
     { name = "requests" },
@@ -1481,6 +1481,10 @@ dependencies = [
     { name = "sphinxcontrib-jquery" },
     { name = "typeguard" },
     { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/29/c4/63c86d3ee0414e30edc30a2ea7c05f9f3e39bba61ed5e0481e275c52559a/sphinx_needs-6.0.1.tar.gz", hash = "sha256:4f6af9711c48e0cc85ecc6d7b592356a80d72bb2be6d1add1ac8fc218402b4d0", size = 27576446, upload-time = "2025-10-02T12:14:24.251Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/72/08/cef70d961e95aea271a4b497b0cc249ef44e036309095a3f88971632faca/sphinx_needs-6.0.1-py3-none-any.whl", hash = "sha256:330422c06f0b5863dae3c24d8bb2c0ba6e4ec036ea19a557aa9646a5bc51e983", size = 2679092, upload-time = "2025-10-02T12:14:21.683Z" },
 ]
 
 [package.optional-dependencies]
@@ -1510,10 +1514,10 @@ requires-dist = [
     { name = "sphinx", extras = ["test"], specifier = ">=8.2.3" },
     { name = "sphinx-design", specifier = ">=0.6.1" },
     { name = "sphinx-immaterial", specifier = ">=0.13.6" },
-    { name = "sphinx-needs", extras = ["plotting"], git = "https://github.com/useblocks/sphinx-needs.git?rev=02eb6e771a6cc39cc8875c9a77520c02135cc084" },
+    { name = "sphinx-needs", extras = ["plotting"], specifier = "==6.0.1" },
     { name = "sphinx-preview", specifier = ">=0.1.2" },
     { name = "sphinx-simplepdf", specifier = ">=1.6.0" },
-    { name = "sphinx-test-reports", git = "https://github.com/useblocks/sphinx-test-reports.git?rev=23a1f6b9cd1454e6637b18945a7c55f49ed8d283" },
+    { name = "sphinx-test-reports", git = "https://github.com/useblocks/sphinx-test-reports.git?rev=7a12d1c00ad051f67a5b0cdedb82c25a012eefdd" },
     { name = "sphinxcontrib-plantuml", specifier = ">=0.30" },
 ]
 
@@ -1544,7 +1548,7 @@ wheels = [
 [[package]]
 name = "sphinx-test-reports"
 version = "1.3.0"
-source = { git = "https://github.com/useblocks/sphinx-test-reports.git?rev=23a1f6b9cd1454e6637b18945a7c55f49ed8d283#23a1f6b9cd1454e6637b18945a7c55f49ed8d283" }
+source = { git = "https://github.com/useblocks/sphinx-test-reports.git?rev=7a12d1c00ad051f67a5b0cdedb82c25a012eefdd#7a12d1c00ad051f67a5b0cdedb82c25a012eefdd" }
 dependencies = [
     { name = "lxml" },
     { name = "sphinx" },

--- a/uv.lock
+++ b/uv.lock
@@ -1517,7 +1517,7 @@ requires-dist = [
     { name = "sphinx-needs", extras = ["plotting"], specifier = "==6.0.1" },
     { name = "sphinx-preview", specifier = ">=0.1.2" },
     { name = "sphinx-simplepdf", specifier = ">=1.6.0" },
-    { name = "sphinx-test-reports", git = "https://github.com/useblocks/sphinx-test-reports.git?rev=7a12d1c00ad051f67a5b0cdedb82c25a012eefdd" },
+    { name = "sphinx-test-reports", specifier = "==1.3.1" },
     { name = "sphinxcontrib-plantuml", specifier = ">=0.30" },
 ]
 
@@ -1547,12 +1547,16 @@ wheels = [
 
 [[package]]
 name = "sphinx-test-reports"
-version = "1.3.0"
-source = { git = "https://github.com/useblocks/sphinx-test-reports.git?rev=7a12d1c00ad051f67a5b0cdedb82c25a012eefdd#7a12d1c00ad051f67a5b0cdedb82c25a012eefdd" }
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "lxml" },
     { name = "sphinx" },
     { name = "sphinx-needs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ec/e6/05c00cbd42170b07ec07de388546ac2c70ed9917d5157f491ce761154d07/sphinx_test_reports-1.3.1.tar.gz", hash = "sha256:e7a550681c1231507d4385506944fb3b551c49670b4058220cf98937eaf4eba6", size = 18559, upload-time = "2025-10-02T13:24:23.566Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b1/dc/2f4590f4d62c75a3bef05d42641228b432a0db65362705b72b10f399b0ae/sphinx_test_reports-1.3.1-py3-none-any.whl", hash = "sha256:750c6d6591158a85f4d677216b598d4c9e3e51f11987d5b4d3cee70247472bcc", size = 25777, upload-time = "2025-10-02T13:24:22.425Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Sphinx-Test-Reports was updated to 1.3.1 that now also supports SN 6 (and SN 5.1).