### PR TITLE
🐛 Fix RTD uv build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -21,9 +21,6 @@ build:
     pre_create_environment:
       - echo "DOT details"
       - which dot
-    post_create_environment:
-      - pip install uv
-      - uv sync --all-groups --all-extras --python $READTHEDOCS_VIRTUALENV_PATH/bin/python
 # Build documentation in the "docs/" directory with Sphinx
 sphinx:
   configuration: docs/conf.py
@@ -37,7 +34,7 @@ sphinx:
 # to build your documentation
 # See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
 # Dependencies are installed via uv sync in post_create_environment
-# python:
-#    install:
-#    - method: pip
-#      path: .
+python:
+   install:
+   - method: pip
+     path: .


### PR DESCRIPTION
Use pip to install dependencies. Does not use `uv.lock`, that's sub-optimal.

Not sure how RTD can work with `uv`.