### PR TITLE
Switch to Furo theme

### DIFF
--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -2,11 +2,6 @@ span.sp_preview_icon {
     color: rgba(0,0,0,0.6) !important
 }
 
-.md-grid {
-max-width: 80rem !important;
-
-}
-
 table.need {
     width: 100% !important;
 }

--- a/docs/_static/furo.css
+++ b/docs/_static/furo.css
@@ -1,0 +1,260 @@
+/* Styling for the https://github.com/pradyunsg/furo theme. */
+
+:root {
+    --ub-color-neutral-0: #FFFFFF;
+    --ub-color-neutral-50: #FAFAFA;
+    --ub-color-neutral-100: #F5F5F5;
+    --ub-color-neutral-200: #EEEEEE;
+    --ub-color-neutral-300: #E0E0E0;
+    --ub-color-neutral-400: #BDBDBD;
+    --ub-color-neutral-500: #9E9E9E;
+    --ub-color-neutral-600: #757575;
+    --ub-color-neutral-700: #616161;
+    --ub-color-neutral-800: #424242;
+    --ub-color-neutral-900: #212121;
+    --ub-color-neutral-1000: #000000;
+}
+
+/* furo light colors */
+body {
+    --ub-color-brand-main: #583eff;
+    --ub-color-brand-muted: #b7a3ff;
+    --ub-color-brand-opaque: rgb(88, 62, 255, 0.2);
+
+    --color-brand-primary: var(--ub-color-brand-main);
+
+    /* anchored heading title */
+    --color-highlight-on-target: var(--ub-color-brand-opaque);
+
+    /* Left ToC */
+    --color-sidebar-brand-text: var(--color-foreground-primary);
+    --color-sidebar-caption-text: var(--ub-color-neutral-900);
+    --color-sidebar-link-text--top-level: var(--ub-color-neutral-800);
+    --color-sidebar-link-text: var(--ub-color-neutral-600);
+    --color-sidebar-link-text--current: var(--ub-color-brand-main);
+    --color-sidebar-item-background--hover: var(--ub-color-brand-opaque);
+
+    /* Right ToC */
+    --color-toc-item-text--active: var(--ub-color-brand-main);
+
+    /* Links */
+    --color-link: var(--color-content-foreground);
+    --color-link--hover: var(--color-content-foreground);
+    --color-link-underline: var(--ub-color-brand-muted);
+    --color-link-underline--hover: var(--ub-color-brand-main);
+    --color-link--visited: var(--color-content-foreground);
+    --color-link--visited--hover: var(--color-content-foreground);
+    --color-link-underline--visited: var(--ub-color-brand-muted);
+    --color-link-underline--visited--hover: var(--ub-color-brand-main);
+
+    /* Admonitions */
+    --color-admonition-title-background--note: var(--ub-color-brand-opaque);
+    --color-admonition-title--note: var(--ub-color-brand-main);
+
+    /* Sphinx Design */
+    --sd-fontsize-dropdown: var(--admonition-font-size);
+    --sd-fontsize-dropdown-title: var(--admonition-title-font-size);
+    --sd-fontweight-dropdown-title: 500;
+    --sd-color-card-header: var(--ub-color-brand-opaque);
+    --sd-color-card-border-hover: var(--ub-color-brand-opaque);
+}
+
+/* furo dark colors */
+@media not print {
+    body[data-theme="dark"] {
+
+        --ub-color-brand-main: #e4ff3e;
+        --ub-color-brand-muted: #b3bb00;
+        --ub-color-brand-opaque: rgba(228, 255, 62, 0.15);
+
+        --color-brand-primary: var(--ub-color-brand-main);
+
+        /* anchored heading title */
+        --color-highlight-on-target: var(--ub-color-brand-opaque);
+
+        /* Left ToC */
+        --color-sidebar-brand-text: var(--color-foreground-primary);
+        --color-sidebar-caption-text: var(--ub-color-neutral-100);
+        --color-sidebar-link-text--top-level: var(--ub-color-neutral-300);
+        --color-sidebar-link-text: var(--ub-color-neutral-500);
+        --color-sidebar-link-text--current: var(--ub-color-brand-main);
+        --color-sidebar-item-background--hover: var(--ub-color-brand-opaque);
+
+        /* Right ToC */
+        --color-toc-item-text--active: var(--ub-color-brand-main);
+
+        /* Links */
+        --color-link: var(--color-content-foreground);
+        --color-link--hover: var(--color-content-foreground);
+        --color-link-underline: var(--ub-color-brand-muted);
+        --color-link-underline--hover: var(--ub-color-brand-main);
+        --color-link--visited: var(--color-content-foreground);
+        --color-link--visited--hover: var(--color-content-foreground);
+        --color-link-underline--visited: var(--ub-color-brand-muted);
+        --color-link-underline--visited--hover: var(--ub-color-brand-main);
+
+        /* Admonitions */
+        --color-admonition-title-background--note: var(--ub-color-brand-opaque);
+        --color-admonition-title--note: var(--ub-color-brand-main);
+    }
+
+    @media (prefers-color-scheme: dark) {
+        body:not([data-theme="light"]) {
+
+            --ub-color-brand-main: #e4ff3e;
+            --ub-color-brand-muted: #b3bb00;
+            --ub-color-brand-opaque: rgba(228, 255, 62, 0.15);
+
+            --color-brand-primary: var(--ub-color-brand-main);
+
+            /* anchored heading title */
+            --color-highlight-on-target: var(--ub-color-brand-opaque);
+
+            /* Left ToC */
+            --color-sidebar-brand-text: var(--color-foreground-primary);
+            --color-sidebar-caption-text: var(--ub-color-neutral-100);
+            --color-sidebar-link-text--top-level: var(--ub-color-neutral-300);
+            --color-sidebar-link-text: var(--ub-color-neutral-500);
+            --color-sidebar-link-text--current: var(--ub-color-brand-main);
+            --color-sidebar-item-background--hover: var(--ub-color-brand-opaque);
+
+            /* Right ToC */
+            --color-toc-item-text--active: var(--ub-color-brand-main);
+
+            /* Links */
+            --color-link: var(--color-content-foreground);
+            --color-link--hover: var(--color-content-foreground);
+            --color-link-underline: var(--ub-color-brand-muted);
+            --color-link-underline--hover: var(--ub-color-brand-main);
+            --color-link--visited: var(--color-content-foreground);
+            --color-link--visited--hover: var(--color-content-foreground);
+            --color-link-underline--visited: var(--ub-color-brand-muted);
+            --color-link-underline--visited--hover: var(--ub-color-brand-main);
+
+            /* Admonitions */
+            --color-admonition-title-background--note: var(--ub-color-brand-opaque);
+            --color-admonition-title--note: var(--ub-color-brand-main);
+        }
+    }
+}
+
+/* sphinx-needs colors */
+body {
+    --color-code-background: #eeffcc;
+    --color-code-foreground: black;
+    --sn-color-need-border: #555;
+    --sn-color-need-row-border: hsla(232, 75%, 95%, 0.12);
+    --sn-color-need-bg: #eee;
+    --sn-color-need-bg-head: rgba(0, 0, 0, 0.1);
+    --sn-color-complete-bg-head: rgba(0, 0, 0, 0.1);
+    --sn-color-complete-bg-foot: rgba(0, 0, 0, 0.1);
+    --sn-color-bg-gray: #eee;
+    --sn-color-bg-lightgray: rgba(0, 0, 0, 0.004);
+    --sn-color-bg-green: #05c46b;
+    --sn-color-bg-red: #ff3f34;
+    --sn-color-bg-yellow: #ffc048;
+    --sn-color-bg-blue: #0fbcf9;
+    --sn-color-debug-btn-border: #333;
+    --sn-color-debug-btn-on-text: #f43333;
+    --sn-color-debug-btn-off-text: #096285;
+    --sn-color-datatable-label: var(--color-foreground-muted);
+    --sn-color-datatable-btn-border: var(--color-foreground-muted);
+}
+
+@media not print {
+    body[data-theme="dark"] {
+        --color-code-background: #202020;
+        --color-code-foreground: #d0d0d0;
+        --sn-color-need-border: #aaaaaa;
+        --sn-color-need-row-border: hsla(52, 75%, 5%, 0.12);
+        --sn-color-need-bg: #111111;
+        --sn-color-need-bg-head: rgba(255, 255, 255, 0.1);
+        --sn-color-complete-bg-head: rgba(255, 255, 255, 0.1);
+        --sn-color-complete-bg-foot: rgba(255, 255, 255, 0.1);
+        --sn-color-bg-gray: #111111;
+        --sn-color-bg-lightgray: rgba(255, 255, 255, 0.1);
+        --sn-color-bg-green: #024e2a;
+        --sn-color-bg-red: #81201b;
+        --sn-color-bg-yellow: #a97c32;
+        --sn-color-bg-blue: #096285;
+        --sn-color-debug-btn-border: #888;
+        --sn-color-debug-btn-on-text: #ff3f34;
+        --sn-color-debug-btn-off-text: #0fbcf9;
+    }
+
+    @media (prefers-color-scheme: dark) {
+        body:not([data-theme="light"]) {
+            --color-code-background: #202020;
+            --color-code-foreground: #d0d0d0;
+            --sn-color-need-border: #aaaaaa;
+            --sn-color-need-row-border: hsla(52, 75%, 5%, 0.12);
+            --sn-color-need-bg: #111111;
+            --sn-color-need-bg-head: rgba(255, 255, 255, 0.1);
+            --sn-color-complete-bg-head: rgba(255, 255, 255, 0.1);
+            --sn-color-complete-bg-foot: rgba(255, 255, 255, 0.1);
+            --sn-color-bg-gray: #111111;
+            --sn-color-bg-lightgray: rgba(255, 255, 255, 0.1);
+            --sn-color-bg-green: #024e2a;
+            --sn-color-bg-red: #81201b;
+            --sn-color-bg-yellow: #a97c32;
+            --sn-color-bg-blue: #096285;
+            --sn-color-debug-btn-border: #888;
+            --sn-color-debug-btn-on-text: #ff3f34;
+            --sn-color-debug-btn-off-text: #0fbcf9;
+        }
+    }
+}
+
+/* make the left ToC use the brand color for the current page */
+.sidebar-tree .current-page>.reference {
+    font-weight: 700;
+    color: var(--ub-color-brand-main)
+}
+
+/* styling for the icon at the top of the left ToC bar */
+img.sidebar-logo {
+    /* furo sets this at 100% but that makes it a bit too big */
+    max-width: 85%;
+}
+
+/* Do not underline links in the search results */
+#search-results a {
+    text-decoration: none;
+}
+
+/* Make PlantUML diagrams and needpie charts scale to the full content width */
+p.plantuml img,
+img[id^="needpie-"] {
+    width: 100%;
+    height: auto;
+}
+
+/* Image width fix in need-sidebars. */
+tbody div.needs_side img.needs_image {
+    max-width: 100px;
+}
+
+/** sphinx-design additional styling **/
+svg.fill-primary {
+    fill: var(--sd-color-primary);
+}
+
+details.sd-dropdown {
+    margin: 1rem auto;
+}
+
+summary.sd-summary-title {
+    padding-right: .5em !important;
+}
+
+.sn-dropdown-default .sd-summary-icon svg {
+    color: var(--color-admonition-title--note);
+}
+
+.sn-dropdown-default {
+    border-left: .2rem solid var(--color-admonition-title--note) !important;
+}
+
+.sn-dropdown-default .sd-summary-title {
+    border-width: 0 !important;
+}

--- a/docs/automotive-adas/analysis.rst
+++ b/docs/automotive-adas/analysis.rst
@@ -11,9 +11,9 @@ Overview
    :filter: docname is not None and "automotive-adas" in docname
    :columns: id, title, type, status, author
 
-.. tip::
-   :title: Big picture
-   :collapsible:
+.. dropdown:: Big picture
+   :icon: light-bulb
+   :color: success
 
    .. needflow::
       :filter: docname is not None and "automotive-adas" in docname

--- a/docs/automotive-adas/external_data.rst
+++ b/docs/automotive-adas/external_data.rst
@@ -22,9 +22,9 @@ PRs
    :+links: SWREQ_001
 
 
-.. tip::
-   :title: Show used documentation code.
-   :collapsible:
+.. dropdown:: Show used documentation code.
+   :icon: light-bulb
+   :color: success
 
    .. code-block:: rst
 
@@ -48,9 +48,9 @@ Issues
 .. needextend:: "Lane Deviation" in title
    :+links:  SWREQ_002
 
-.. tip::
-   :title: Show used documentation code.
-   :collapsible:
+.. dropdown:: Show used documentation code.
+   :icon: light-bulb
+   :color: success
 
    .. code-block:: rst
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,7 +18,7 @@ print(f"CODE_PATH: {code_path}")
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
 project = "Sphinx-Needs Demo"
-copyright = "2024, team useblocks"
+copyright = "2026, team useblocks"
 author = "team useblocks"
 version = "1.0"
 
@@ -38,18 +38,6 @@ extensions = [
     "sphinx_preview","sphinx_design"
 ]
 
-# During a PDF build with Sphinx-SimplePDF, a special theme is used.
-# But adding "sphinx_immaterial" to the extension list, the "immaterial" already
-# does a lot of sphinx voodoo, which is not needed and does not work during a PDF build.
-# Therefore we add it only, if a special ENV-Var is not set.
-#
-# As we can't ask Sphinx already in the config file, which Builder will be used, we need
-# to set this information by hand, or in this case via an ENV var.
-#
-# To build HTML, just call ``make html
-# To build PDF, call ``env PDF=1 make simplepdf"
-if os.environ.get("PDF", "0") != "1":
-    extensions.append("sphinx_immaterial")
 
 ###############################################################################
 # SPHINX-NEEDS Config START
@@ -101,12 +89,11 @@ tr_file_option = "test_file"
 # Docs: https://sphinx-preview.readthedocs.io/en/latest/#configuration
 preview_config = {
     # Add a preview icon only for this type of links
-    # This is very theme and HTML specific. In this case "div-mo-content" is the content area
-    # and we handle all links there.
-    "selector": "div.md-content a",
+    # This is very theme and HTML specific. In this case the Furo main article area.
+    "selector": "article#furo-main-content a",
     # A list of selectors, where no preview icon shall be added, because it makes often no sense.
     # For instance the own ID of a need object, or the link on an image to open the image.
-    "not_selector": "div.needs_head a, h1 a, h2 a, a.headerlink, a.md-content__button, a.image-reference, em.sig-param a, a.paginate_button, a.sd-btn",
+    "not_selector": "div.needs_head a, h1 a, h2 a, a.headerlink, a.back-to-top, a.image-reference, em.sig-param a, a.paginate_button, a.sd-btn",
     "set_icon": True,
     "icon_only": True,
     "icon_click": True,
@@ -144,70 +131,33 @@ plantuml_output_format = "svg_img"
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
-html_theme = "alabaster"  # Sphinx Defaul Theme
-
-# Set ``html_theme`` to ``sphinx_immaterial`` only, if we do NOT perform a PDF build.
-if os.environ.get("PDF", 0) != 1:
-    html_theme = "sphinx_immaterial"
+html_theme = "furo"
 
 html_static_path = ["_static"]
 
-sphinx_immaterial_override_generic_admonitions = True
-
 html_logo = "_images/sphinx-needs-logo.png"
 html_theme_options = {
-    "font": False,
-    "icon": {
-        "repo": "fontawesome/brands/github",
-        "edit": "material/file-edit-outline",
-    },
-    "site_url": "https://jbms.github.io/sphinx-immaterial/",
-    "repo_url": "https://github.com/useblocks/sphinx-needs-demo",
-    "repo_name": "Sphinx-Needs Demo",
-    "edit_uri": "blob/main/docs",
-    "globaltoc_collapse": False,
-    "features": [
-        "navigation.expand",
-        # "navigation.tabs",
-        # "toc.integrate",
-        "navigation.sections",
-        # "navigation.instant",
-        # "header.autohide",
-        "navigation.top",
-        # "navigation.tracking",
-        "search.highlight",
-        "search.share",
-        "toc.follow",
-        "toc.sticky",
-        "content.tabs.link",
-        "announce.dismiss",
-    ],
-    "palette": [
+    "sidebar_hide_name": True,
+    "top_of_page_buttons": ["view", "edit"],
+    "source_repository": "https://github.com/useblocks/sphinx-needs-demo",
+    "source_branch": "main",
+    "source_directory": "docs/",
+    "footer_icons": [
         {
-            "media": "(prefers-color-scheme: light)",
-            "scheme": "default",
-            "primary": "blue",
-            "accent": "light-cyan",
-            # "toggle": {
-            #     "icon": "material/lightbulb-outline",
-            #     "name": "Switch to dark mode",
-            # },
+            "name": "GitHub",
+            "url": "https://github.com/useblocks/sphinx-needs-demo",
+            "html": """
+                <svg stroke="currentColor" fill="currentColor" stroke-width="0" viewBox="0 0 16 16">
+                    <path fill-rule="evenodd" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"></path>
+                </svg>
+            """,
+            "class": "",
         },
-        # {
-        #     "media": "(prefers-color-scheme: dark)",
-        #     "scheme": "slate",
-        #     "primary": "blue",
-        #     "accent": "light-cyan",
-        #     "toggle": {
-        #         "icon": "material/lightbulb",
-        #         "name": "Switch to light mode",
-        #     },
-        # },
     ],
-    "toc_title_is_page_title": True,
 }
 
 html_css_files = [
+    "furo.css",
     "custom.css",
 ]
 

--- a/docs/demo_details.rst
+++ b/docs/demo_details.rst
@@ -21,7 +21,7 @@ Extensions
 :`Sphinx-Design <https://sphinx-design.readthedocs.io>`__:
     Provides features to layout the content or to use dropdown, buttons or tabs.
 
-:`Sphinx-Immaterial <https://jbms.github.io/sphinx-immaterial/>`__:
+:`Furo <https://pradyunsg.me/furo/>`__:
     The Sphinx theme for this documentation.
 
 :`Sphinxcontrib-PlantUML <https://github.com/sphinx-contrib/plantuml>`__:

--- a/docs/demo_hints/constraints.rst
+++ b/docs/demo_hints/constraints.rst
@@ -1,6 +1,6 @@
-.. tip::
-      :title: Demo feature hint: Constraints
-      :collapsible:
+.. dropdown:: Demo feature hint: Constraints
+      :icon: light-bulb
+      :color: success
 
       For requirements two constraints are defined, which check if the ``status`` is set correctly and if a ``release`` is linked.
 

--- a/docs/demo_page_header.rst
+++ b/docs/demo_page_header.rst
@@ -1,8 +1,8 @@
 .. if-builder:: html
 
-   .. tip::
-      :title: Demo page details
-      :collapsible:
+   .. dropdown:: Demo page details
+      :icon: light-bulb
+      :color: success
 
       **Page source code: {{page}}**
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -51,9 +51,11 @@ The complete source code can be found here: https://github.com/useblocks/sphinx-
 Features and technical details are described inside dropdowns like
 this one:
 
-.. tip:: Really, this is just an example. Nothing more.
-   :title: Demo feature hint: Just an example
-   :collapsible:
+.. dropdown:: Demo feature hint: Just an example
+   :icon: light-bulb
+   :color: success
+
+   Really, this is just an example. Nothing more.
 
 Demo Content
 ------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,6 @@ dependencies = [
     "sphinx-test-reports>=1.3.2",  # pin as RTD consumes this file, not uv.lock
     "furo>=2024.8.6",
     "sphinx-preview>=0.1.2",
-    "sphinx-immaterial>=0.13.6",
 ]
 readme = "README.md"
 requires-python = ">= 3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -37,24 +37,6 @@ wheels = [
 ]
 
 [[package]]
-name = "annotated-types"
-version = "0.7.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
-]
-
-[[package]]
-name = "appdirs"
-version = "1.4.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d7/d8/05696357e0311f5b5c316d7b95f46c669dd9c15aaeecbb48c7d0aeb88c40/appdirs-1.4.4.tar.gz", hash = "sha256:7d5d0167b2b1ba821647616af46a749d1c653740dd0d2415100fe26e27afdf41", size = 13470, upload-time = "2020-05-11T07:59:51.037Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3b/00/2344469e2084fb287c2e0b57b72910309874c3245463acd6cf5e3db69324/appdirs-1.4.4-py2.py3-none-any.whl", hash = "sha256:a841dacd6b99318a741b166adb07e19ee71a274450e68237b4650ca1055ab128", size = 9566, upload-time = "2020-05-11T07:59:49.499Z" },
-]
-
-[[package]]
 name = "attrs"
 version = "25.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1087,76 +1069,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pydantic"
-version = "2.11.9"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "annotated-types" },
-    { name = "pydantic-core" },
-    { name = "typing-extensions" },
-    { name = "typing-inspection" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ff/5d/09a551ba512d7ca404d785072700d3f6727a02f6f3c24ecfd081c7cf0aa8/pydantic-2.11.9.tar.gz", hash = "sha256:6b8ffda597a14812a7975c90b82a8a2e777d9257aba3453f973acd3c032a18e2", size = 788495, upload-time = "2025-09-13T11:26:39.325Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3e/d3/108f2006987c58e76691d5ae5d200dd3e0f532cb4e5fa3560751c3a1feba/pydantic-2.11.9-py3-none-any.whl", hash = "sha256:c42dd626f5cfc1c6950ce6205ea58c93efa406da65f479dcb4029d5934857da2", size = 444855, upload-time = "2025-09-13T11:26:36.909Z" },
-]
-
-[[package]]
-name = "pydantic-core"
-version = "2.33.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ad/88/5f2260bdfae97aabf98f1778d43f69574390ad787afb646292a638c923d4/pydantic_core-2.33.2.tar.gz", hash = "sha256:7cb8bc3605c29176e1b105350d2e6474142d7c1bd1d9327c4a9bdb46bf827acc", size = 435195, upload-time = "2025-04-23T18:33:52.104Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/18/8a/2b41c97f554ec8c71f2a8a5f85cb56a8b0956addfe8b0efb5b3d77e8bdc3/pydantic_core-2.33.2-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:a7ec89dc587667f22b6a0b6579c249fca9026ce7c333fc142ba42411fa243cdc", size = 2009000, upload-time = "2025-04-23T18:31:25.863Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/02/6224312aacb3c8ecbaa959897af57181fb6cf3a3d7917fd44d0f2917e6f2/pydantic_core-2.33.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:3c6db6e52c6d70aa0d00d45cdb9b40f0433b96380071ea80b09277dba021ddf7", size = 1847996, upload-time = "2025-04-23T18:31:27.341Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/46/6dcdf084a523dbe0a0be59d054734b86a981726f221f4562aed313dbcb49/pydantic_core-2.33.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4e61206137cbc65e6d5256e1166f88331d3b6238e082d9f74613b9b765fb9025", size = 1880957, upload-time = "2025-04-23T18:31:28.956Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/6b/1ec2c03837ac00886ba8160ce041ce4e325b41d06a034adbef11339ae422/pydantic_core-2.33.2-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:eb8c529b2819c37140eb51b914153063d27ed88e3bdc31b71198a198e921e011", size = 1964199, upload-time = "2025-04-23T18:31:31.025Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/1d/6bf34d6adb9debd9136bd197ca72642203ce9aaaa85cfcbfcf20f9696e83/pydantic_core-2.33.2-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c52b02ad8b4e2cf14ca7b3d918f3eb0ee91e63b3167c32591e57c4317e134f8f", size = 2120296, upload-time = "2025-04-23T18:31:32.514Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/94/2bd0aaf5a591e974b32a9f7123f16637776c304471a0ab33cf263cf5591a/pydantic_core-2.33.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:96081f1605125ba0855dfda83f6f3df5ec90c61195421ba72223de35ccfb2f88", size = 2676109, upload-time = "2025-04-23T18:31:33.958Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/41/4b043778cf9c4285d59742281a769eac371b9e47e35f98ad321349cc5d61/pydantic_core-2.33.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8f57a69461af2a5fa6e6bbd7a5f60d3b7e6cebb687f55106933188e79ad155c1", size = 2002028, upload-time = "2025-04-23T18:31:39.095Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/d5/7bb781bf2748ce3d03af04d5c969fa1308880e1dca35a9bd94e1a96a922e/pydantic_core-2.33.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:572c7e6c8bb4774d2ac88929e3d1f12bc45714ae5ee6d9a788a9fb35e60bb04b", size = 2100044, upload-time = "2025-04-23T18:31:41.034Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/36/def5e53e1eb0ad896785702a5bbfd25eed546cdcf4087ad285021a90ed53/pydantic_core-2.33.2-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:db4b41f9bd95fbe5acd76d89920336ba96f03e149097365afe1cb092fceb89a1", size = 2058881, upload-time = "2025-04-23T18:31:42.757Z" },
-    { url = "https://files.pythonhosted.org/packages/01/6c/57f8d70b2ee57fc3dc8b9610315949837fa8c11d86927b9bb044f8705419/pydantic_core-2.33.2-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:fa854f5cf7e33842a892e5c73f45327760bc7bc516339fda888c75ae60edaeb6", size = 2227034, upload-time = "2025-04-23T18:31:44.304Z" },
-    { url = "https://files.pythonhosted.org/packages/27/b9/9c17f0396a82b3d5cbea4c24d742083422639e7bb1d5bf600e12cb176a13/pydantic_core-2.33.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:5f483cfb75ff703095c59e365360cb73e00185e01aaea067cd19acffd2ab20ea", size = 2234187, upload-time = "2025-04-23T18:31:45.891Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/6a/adf5734ffd52bf86d865093ad70b2ce543415e0e356f6cacabbc0d9ad910/pydantic_core-2.33.2-cp312-cp312-win32.whl", hash = "sha256:9cb1da0f5a471435a7bc7e439b8a728e8b61e59784b2af70d7c169f8dd8ae290", size = 1892628, upload-time = "2025-04-23T18:31:47.819Z" },
-    { url = "https://files.pythonhosted.org/packages/43/e4/5479fecb3606c1368d496a825d8411e126133c41224c1e7238be58b87d7e/pydantic_core-2.33.2-cp312-cp312-win_amd64.whl", hash = "sha256:f941635f2a3d96b2973e867144fde513665c87f13fe0e193c158ac51bfaaa7b2", size = 1955866, upload-time = "2025-04-23T18:31:49.635Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/24/8b11e8b3e2be9dd82df4b11408a67c61bb4dc4f8e11b5b0fc888b38118b5/pydantic_core-2.33.2-cp312-cp312-win_arm64.whl", hash = "sha256:cca3868ddfaccfbc4bfb1d608e2ccaaebe0ae628e1416aeb9c4d88c001bb45ab", size = 1888894, upload-time = "2025-04-23T18:31:51.609Z" },
-    { url = "https://files.pythonhosted.org/packages/46/8c/99040727b41f56616573a28771b1bfa08a3d3fe74d3d513f01251f79f172/pydantic_core-2.33.2-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:1082dd3e2d7109ad8b7da48e1d4710c8d06c253cbc4a27c1cff4fbcaa97a9e3f", size = 2015688, upload-time = "2025-04-23T18:31:53.175Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/cc/5999d1eb705a6cefc31f0b4a90e9f7fc400539b1a1030529700cc1b51838/pydantic_core-2.33.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f517ca031dfc037a9c07e748cefd8d96235088b83b4f4ba8939105d20fa1dcd6", size = 1844808, upload-time = "2025-04-23T18:31:54.79Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/5e/a0a7b8885c98889a18b6e376f344da1ef323d270b44edf8174d6bce4d622/pydantic_core-2.33.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0a9f2c9dd19656823cb8250b0724ee9c60a82f3cdf68a080979d13092a3b0fef", size = 1885580, upload-time = "2025-04-23T18:31:57.393Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/2a/953581f343c7d11a304581156618c3f592435523dd9d79865903272c256a/pydantic_core-2.33.2-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2b0a451c263b01acebe51895bfb0e1cc842a5c666efe06cdf13846c7418caa9a", size = 1973859, upload-time = "2025-04-23T18:31:59.065Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/55/f1a813904771c03a3f97f676c62cca0c0a4138654107c1b61f19c644868b/pydantic_core-2.33.2-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1ea40a64d23faa25e62a70ad163571c0b342b8bf66d5fa612ac0dec4f069d916", size = 2120810, upload-time = "2025-04-23T18:32:00.78Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/c3/053389835a996e18853ba107a63caae0b9deb4a276c6b472931ea9ae6e48/pydantic_core-2.33.2-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0fb2d542b4d66f9470e8065c5469ec676978d625a8b7a363f07d9a501a9cb36a", size = 2676498, upload-time = "2025-04-23T18:32:02.418Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/3c/f4abd740877a35abade05e437245b192f9d0ffb48bbbbd708df33d3cda37/pydantic_core-2.33.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9fdac5d6ffa1b5a83bca06ffe7583f5576555e6c8b3a91fbd25ea7780f825f7d", size = 2000611, upload-time = "2025-04-23T18:32:04.152Z" },
-    { url = "https://files.pythonhosted.org/packages/59/a7/63ef2fed1837d1121a894d0ce88439fe3e3b3e48c7543b2a4479eb99c2bd/pydantic_core-2.33.2-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:04a1a413977ab517154eebb2d326da71638271477d6ad87a769102f7c2488c56", size = 2107924, upload-time = "2025-04-23T18:32:06.129Z" },
-    { url = "https://files.pythonhosted.org/packages/04/8f/2551964ef045669801675f1cfc3b0d74147f4901c3ffa42be2ddb1f0efc4/pydantic_core-2.33.2-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:c8e7af2f4e0194c22b5b37205bfb293d166a7344a5b0d0eaccebc376546d77d5", size = 2063196, upload-time = "2025-04-23T18:32:08.178Z" },
-    { url = "https://files.pythonhosted.org/packages/26/bd/d9602777e77fc6dbb0c7db9ad356e9a985825547dce5ad1d30ee04903918/pydantic_core-2.33.2-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:5c92edd15cd58b3c2d34873597a1e20f13094f59cf88068adb18947df5455b4e", size = 2236389, upload-time = "2025-04-23T18:32:10.242Z" },
-    { url = "https://files.pythonhosted.org/packages/42/db/0e950daa7e2230423ab342ae918a794964b053bec24ba8af013fc7c94846/pydantic_core-2.33.2-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:65132b7b4a1c0beded5e057324b7e16e10910c106d43675d9bd87d4f38dde162", size = 2239223, upload-time = "2025-04-23T18:32:12.382Z" },
-    { url = "https://files.pythonhosted.org/packages/58/4d/4f937099c545a8a17eb52cb67fe0447fd9a373b348ccfa9a87f141eeb00f/pydantic_core-2.33.2-cp313-cp313-win32.whl", hash = "sha256:52fb90784e0a242bb96ec53f42196a17278855b0f31ac7c3cc6f5c1ec4811849", size = 1900473, upload-time = "2025-04-23T18:32:14.034Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/75/4a0a9bac998d78d889def5e4ef2b065acba8cae8c93696906c3a91f310ca/pydantic_core-2.33.2-cp313-cp313-win_amd64.whl", hash = "sha256:c083a3bdd5a93dfe480f1125926afcdbf2917ae714bdb80b36d34318b2bec5d9", size = 1955269, upload-time = "2025-04-23T18:32:15.783Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/86/1beda0576969592f1497b4ce8e7bc8cbdf614c352426271b1b10d5f0aa64/pydantic_core-2.33.2-cp313-cp313-win_arm64.whl", hash = "sha256:e80b087132752f6b3d714f041ccf74403799d3b23a72722ea2e6ba2e892555b9", size = 1893921, upload-time = "2025-04-23T18:32:18.473Z" },
-    { url = "https://files.pythonhosted.org/packages/a4/7d/e09391c2eebeab681df2b74bfe6c43422fffede8dc74187b2b0bf6fd7571/pydantic_core-2.33.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:61c18fba8e5e9db3ab908620af374db0ac1baa69f0f32df4f61ae23f15e586ac", size = 1806162, upload-time = "2025-04-23T18:32:20.188Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/3d/847b6b1fed9f8ed3bb95a9ad04fbd0b212e832d4f0f50ff4d9ee5a9f15cf/pydantic_core-2.33.2-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:95237e53bb015f67b63c91af7518a62a8660376a6a0db19b89acc77a4d6199f5", size = 1981560, upload-time = "2025-04-23T18:32:22.354Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/9a/e73262f6c6656262b5fdd723ad90f518f579b7bc8622e43a942eec53c938/pydantic_core-2.33.2-cp313-cp313t-win_amd64.whl", hash = "sha256:c2fc0a768ef76c15ab9238afa6da7f69895bb5d1ee83aeea2e3509af4472d0b9", size = 1935777, upload-time = "2025-04-23T18:32:25.088Z" },
-]
-
-[[package]]
-name = "pydantic-extra-types"
-version = "2.10.5"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pydantic" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/7e/ba/4178111ec4116c54e1dc7ecd2a1ff8f54256cdbd250e576882911e8f710a/pydantic_extra_types-2.10.5.tar.gz", hash = "sha256:1dcfa2c0cf741a422f088e0dbb4690e7bfadaaf050da3d6f80d6c3cf58a2bad8", size = 138429, upload-time = "2025-06-02T09:31:52.713Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/70/1a/5f4fd9e7285f10c44095a4f9fe17d0f358d1702a7c74a9278c794e8a7537/pydantic_extra_types-2.10.5-py3-none-any.whl", hash = "sha256:b60c4e23d573a69a4f1a16dd92888ecc0ef34fb0e655b4f305530377fa70e7a8", size = 38315, upload-time = "2025-06-02T09:31:51.229Z" },
-]
-
-[[package]]
 name = "pydyf"
 version = "0.11.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1539,23 +1451,6 @@ wheels = [
 ]
 
 [[package]]
-name = "sphinx-immaterial"
-version = "0.13.6"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "appdirs" },
-    { name = "markupsafe" },
-    { name = "pydantic" },
-    { name = "pydantic-extra-types" },
-    { name = "requests" },
-    { name = "sphinx" },
-    { name = "typing-extensions" },
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d9/11/cabf2ba4f0ca757e3c7d93917afc623597c60ae41bc6b52dce3c278bb0e0/sphinx_immaterial-0.13.6-py3-none-any.whl", hash = "sha256:4c7dce949967fa0905f71e5af22ba781f2dc9a22f2c6d4e0cef166cef099871c", size = 11409972, upload-time = "2025-08-14T00:15:08.044Z" },
-]
-
-[[package]]
 name = "sphinx-needs"
 version = "7.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1588,7 +1483,6 @@ dependencies = [
     { name = "sphinx", extra = ["test"] },
     { name = "sphinx-codelinks" },
     { name = "sphinx-design" },
-    { name = "sphinx-immaterial" },
     { name = "sphinx-needs", extra = ["plotting"] },
     { name = "sphinx-preview" },
     { name = "sphinx-simplepdf" },
@@ -1602,7 +1496,6 @@ requires-dist = [
     { name = "sphinx", extras = ["test"], specifier = ">=8.2.3" },
     { name = "sphinx-codelinks", specifier = ">=1.2.0" },
     { name = "sphinx-design", specifier = ">=0.6.1" },
-    { name = "sphinx-immaterial", specifier = ">=0.13.6" },
     { name = "sphinx-needs", extras = ["plotting"], specifier = ">=7.0.0,<8" },
     { name = "sphinx-preview", specifier = ">=0.1.2" },
     { name = "sphinx-simplepdf", specifier = ">=1.6.0" },
@@ -1782,6 +1675,14 @@ version = "0.23.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/22/85/a61c782afbb706a47d990eaee6977e7c2bd013771c5bf5c81c617684f286/tree_sitter_c_sharp-0.23.1.tar.gz", hash = "sha256:322e2cfd3a547a840375276b2aea3335fa6458aeac082f6c60fec3f745c967eb", size = 1317728, upload-time = "2024-11-11T05:25:32.535Z" }
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/4c/dc/d4a0ad9e466263728f80f9dac399609473af01c1aba2ea3ea8879ce56276/tree_sitter_c_sharp-0.23.1-cp310-abi3-macosx_10_9_x86_64.whl", hash = "sha256:e87be7572991552606a3155d2f6c2045ded8bce94bfd9f74bf521d949c219a1c", size = 333661, upload-time = "2026-04-14T15:11:14.227Z" },
+    { url = "https://files.pythonhosted.org/packages/61/7a/5c862770460a2e27079e725585ad2718100373c09448c14e36934ef44414/tree_sitter_c_sharp-0.23.1-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:86c2fdf178c66474a1be2965602818d30780e4e3ed890e3c206931f65d9a154c", size = 376295, upload-time = "2026-04-14T15:11:15.346Z" },
+    { url = "https://files.pythonhosted.org/packages/67/18/0571a3a34c0feda60a9c37cf6dd5edfdbc24f8fcb1e48b6b6eb0f324ad2a/tree_sitter_c_sharp-0.23.1-cp310-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:035d259e64c41d02cc45afc3b8b46388b232e7d16d84734d851cca7334761da5", size = 358331, upload-time = "2026-04-14T15:11:16.418Z" },
+    { url = "https://files.pythonhosted.org/packages/44/65/0f7e1f50f6365338eb700f01710da0adc49a49fa9a8443e5a90ea4f29491/tree_sitter_c_sharp-0.23.1-cp310-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fa472cb9de7e14fee9408e144f29f68384cd8e9c677dff0002da19f361a59bdf", size = 359444, upload-time = "2026-04-14T15:11:17.509Z" },
+    { url = "https://files.pythonhosted.org/packages/98/60/129bd56d5ef22b4ae254940a09b6d3ed873093218868a3f9635d571d514e/tree_sitter_c_sharp-0.23.1-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:1a0ea86eccff74e85ab4a2cf77c813fad7c84162962ce242dff0c51601028832", size = 358143, upload-time = "2026-04-14T15:11:18.755Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/cd/e12cdca47e0c56151cb4b156d48091b7bc1d968e072c1656cf6b73fe7218/tree_sitter_c_sharp-0.23.1-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:8ab26dc998bbd4b4287b129f67c10ca715deb402ed77d0645674490ea509097e", size = 357524, upload-time = "2026-04-14T15:11:19.717Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/2c/f742d60f818cba83760f4975c7158d1c96c36b5807e95a843db7fb8c64b7/tree_sitter_c_sharp-0.23.1-cp310-abi3-win_amd64.whl", hash = "sha256:d4486653feaff3314ef45534dcb6f9ea8ab3aa160896287c6473788f88eb38be", size = 338755, upload-time = "2026-04-14T15:11:20.883Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/e4/8a8642b9bba86248ac2facc81ffb187c06c6768efa56c79d61fab70d736b/tree_sitter_c_sharp-0.23.1-cp310-abi3-win_arm64.whl", hash = "sha256:e7a14b76ec23cc8386cf662d5ea602d81331376c93ca6299a97b174047790345", size = 337261, upload-time = "2026-04-14T15:11:22.111Z" },
     { url = "https://files.pythonhosted.org/packages/58/04/f6c2df4c53a588ccd88d50851155945cff8cd887bd70c175e00aaade7edf/tree_sitter_c_sharp-0.23.1-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:2b612a6e5bd17bb7fa2aab4bb6fc1fba45c94f09cb034ab332e45603b86e32fd", size = 372235, upload-time = "2024-11-11T05:25:19.424Z" },
     { url = "https://files.pythonhosted.org/packages/99/10/1aa9486f1e28fc22810fa92cbdc54e1051e7f5536a5e5b5e9695f609b31e/tree_sitter_c_sharp-0.23.1-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:1a8b98f62bc53efcd4d971151950c9b9cd5cbe3bacdb0cd69fdccac63350d83e", size = 419046, upload-time = "2024-11-11T05:25:20.679Z" },
     { url = "https://files.pythonhosted.org/packages/0f/21/13df29f8fcb9ba9f209b7b413a4764b673dfd58989a0dd67e9c7e19e9c2e/tree_sitter_c_sharp-0.23.1-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:986e93d845a438ec3c4416401aa98e6a6f6631d644bbbc2e43fcb915c51d255d", size = 415999, upload-time = "2024-11-11T05:25:22.359Z" },
@@ -1875,18 +1776,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
-]
-
-[[package]]
-name = "typing-inspection"
-version = "0.4.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Closes #41

- Replace `sphinx_immaterial` with `furo` as the HTML theme, using useblocks brand colors adapted from ubTrace
- Convert immaterial-specific collapsible `.. tip::` directives to `sphinx-design` `.. dropdown::` directives
- Add GitHub footer icon, update preview config selectors for Furo's DOM structure
- Remove `sphinx-immaterial` dependency (and 6 transitive deps) from `pyproject.toml` / `uv.lock`
- Update copyright to 2026

## Test plan

- [x] `sphinx-build -W` succeeds with zero warnings
- [x] Verified locally in Chrome: page layout, sidebar, light/dark mode CSS variables, dropdowns, PlantUML/needpie scaling, preview icons, GitHub footer icon
- [ ] RTD build succeeds (uses `pip install .` which picks up `furo` from `pyproject.toml`)