### PR TITLE
👌 Add ubTrace publish workflow

### DIFF
--- a/.github/workflows/ubtrace.yml
+++ b/.github/workflows/ubtrace.yml
@@ -1,0 +1,45 @@
+name: ubTrace publish
+
+on:
+  push:
+    branches: [main]
+    tags:
+      - 'v[0-9]*'
+      - '[0-9]*'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version-file: ".python-version"
+
+      - name: Compute UBTRACE_VERSION
+        id: vars
+        run: |
+          if [[ "$GITHUB_REF_TYPE" == "tag" ]]; then
+            version="$GITHUB_REF_NAME"
+          else
+            version="main"
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Build ubTrace artifact
+        working-directory: docs
+        run: |
+          uv run sphinx-build -W -b ubtrace \
+            -D ubtrace_version=${{ steps.vars.outputs.version }} \
+            . _build/ubtrace
+
+      - name: Upload to ubTrace
+        env:
+          UBTRACE_INGEST_TOKEN: ${{ secrets.UBTRACE_INGEST_TOKEN }}
+          UBTRACE_VERSION: ${{ steps.vars.outputs.version }}
+        run: bash upload.sh

--- a/upload.sh
+++ b/upload.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Usage: UBTRACE_INGEST_TOKEN=<token> bash upload.sh
+# The token needs "Ingest" permissions for the target ubTrace instance
+# at team.useblocks.com.
+# UBTRACE_VERSION may be overridden from the environment (CI sets it to
+# the tag name); it defaults to "main" for local manual runs.
+
+export UBTRACE_URL=https://api.team.useblocks.com/api
+: "${UBTRACE_INGEST_TOKEN:?UBTRACE_INGEST_TOKEN is not set (create a token with Ingest permissions on team.useblocks.com and export it first)}"
+export UBTRACE_ORG=useblocks
+export UBTRACE_PROJECT=sphinx-needs-demo
+export UBTRACE_VERSION="${UBTRACE_VERSION:-main}"
+
+# Build the docs. ubt_sphinx writes its output under
+#   docs/_build/ubtrace/<ubtrace_organization>/<ubtrace_project>/<ubtrace_version>/
+# so the values above must match the conf.py settings (or the -D
+# override passed to sphinx-build at build time).
+# sphinx-build -b ubtrace docs docs/_build/ubtrace
+
+# Package the version directory (the one that directly contains needs.json):
+BUILD_DIR="docs/_build/ubtrace/${UBTRACE_ORG}/${UBTRACE_PROJECT}/${UBTRACE_VERSION}"
+tar -czf /tmp/build.tar.gz -C "${BUILD_DIR}" .
+
+# Upload it:
+curl --fail-with-body --show-error \
+  -H "Authorization: Bearer ${UBTRACE_INGEST_TOKEN}" \
+  -F "file=@/tmp/build.tar.gz" \
+  "${UBTRACE_URL}/v1/ingest/${UBTRACE_ORG}/${UBTRACE_PROJECT}/${UBTRACE_VERSION}?overwrite=true"


### PR DESCRIPTION
## Summary

- New GitHub Actions workflow that uploads ubTrace artifacts to `api.team.useblocks.com` on every push to `main` and on semver-shaped tag pushes (`v[0-9]*` and `[0-9]*`)
- Companion `upload.sh` script (env-var-driven, no embedded secrets) wraps the ingest API call so the same code works locally and in CI
- `UBTRACE_VERSION` is computed once from the git ref — `main` for branch pushes, the literal tag name for tag pushes — and threaded through both the sphinx build (`-D ubtrace_version=…`) and the upload step, so the build output dir and the API target version always agree

## Test plan

- [x] Add `UBTRACE_INGEST_TOKEN` repo secret with Ingest scope on team.useblocks.com **before merging** — without it the post-merge workflow fails fast on the upload step
- [ ] After merge, verify the `ubTrace publish` workflow on the merge commit succeeds
- [ ] Confirm the build appears at team.useblocks.com under `useblocks/sphinx-needs-demo/main`
- [ ] (Optional) push a throwaway tag like `v0.0.1-test` and verify it publishes as version `v0.0.1-test`