### PR TITLE
Update ubt-sphinx from 0.6.1 to 0.7.1

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -24,7 +24,7 @@ build:
     post_create_environment:
       # ubt-sphinx is only available on the private pypi.useblocks.com index, not on PyPI.
       # RTD's pip install uses PyPI by default, so we pre-install it here before the main install runs.
-      - pip install --extra-index-url https://pypi.useblocks.com/ "ubt-sphinx==0.6.1"
+      - pip install --extra-index-url https://pypi.useblocks.com/ "ubt-sphinx==0.7.1"
 # Build documentation in the "docs/" directory with Sphinx
 sphinx:
   configuration: docs/conf.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "sphinx-test-reports>=1.3.2",  # pin as RTD consumes this file, not uv.lock
     "furo>=2024.8.6",
     "sphinx-preview>=0.1.2",
-    "ubt-sphinx==0.6.1"
+    "ubt-sphinx==0.7.1"
 ]
 readme = "README.md"
 requires-python = ">= 3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -1103,6 +1103,34 @@ wheels = [
 ]
 
 [[package]]
+name = "polars"
+version = "1.40.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "polars-runtime-32" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/8c/bc9bc948058348ed43117cecc3007cd608f395915dae8a00974579a5dab1/polars-1.40.1.tar.gz", hash = "sha256:ab2694134b137596b5a59bfd7b4c54ebbc9b59f9403127f18e32d363777552e8", size = 733574, upload-time = "2026-04-22T19:15:55.507Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ea/91/74fc60d94488685a92ac9d49d7ec55f3e91fe9b77942a6235a5fa7f249c3/polars-1.40.1-py3-none-any.whl", hash = "sha256:c0f861219d1319cdea45c4ce4d30355a47176b8f98dcedf95ea8269f131b8abd", size = 828723, upload-time = "2026-04-22T19:14:25.452Z" },
+]
+
+[[package]]
+name = "polars-runtime-32"
+version = "1.40.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/54/ba/26d40f039be9f552b5fd7365a621bdfc0f8e912ef77094ae4693491b0bae/polars_runtime_32-1.40.1.tar.gz", hash = "sha256:37f3065615d1bf90d03b5326222df4c5c1f8a5d33e50470aa588e3465e6eb814", size = 2935843, upload-time = "2026-04-22T19:15:57.26Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7d/46/22c8af5eed68ac2eeb556e0fa3ca8a7b798e984ceff4450888f3b5ac61fd/polars_runtime_32-1.40.1-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:b748ef652270cc49e9e69f99a035e0eb4d5f856d42bcd6ac4d9d80a40142aa1e", size = 52098755, upload-time = "2026-04-22T19:14:28.555Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/3e/48599a38009ca60ff82a6f38c8a621ce3c0286aa7397c7d79e741bd9060e/polars_runtime_32-1.40.1-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:d249b3743e05986060cec0a7aaa542d020df6c6b876e556023a310efd581f9be", size = 46367542, upload-time = "2026-04-22T19:14:32.433Z" },
+    { url = "https://files.pythonhosted.org/packages/43/e9/384bc069367a1a36ee31c13782c178dbd039b2b873b772d4a0fc23a2373d/polars_runtime_32-1.40.1-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5987b30e7aa1059d069498496e8dda35afd592b0ac3d46ed87e3ff8df1ad652c", size = 50252104, upload-time = "2026-04-22T19:14:35.945Z" },
+    { url = "https://files.pythonhosted.org/packages/15/ef/7d57ceb0651af74194e97ed6583e148d352f03d696090221b8059cdfc90b/polars_runtime_32-1.40.1-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8d7f42a8b3f16fc66002cc0f6516f7dd7653396886ae0ed362ab95c0b3408b59", size = 56250788, upload-time = "2026-04-22T19:14:39.743Z" },
+    { url = "https://files.pythonhosted.org/packages/10/0f/e4b3ffc748827a14a474ec9c42e45c066050e440fec57e914091d9adda75/polars_runtime_32-1.40.1-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:e5f7becc237a7ec9d9a10878dc8e54b73bbf4e2d94a2991c37d7a0b38590d8f9", size = 50432590, upload-time = "2026-04-22T19:14:43.388Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/0b/b8d95fbed869fa4caabe9c400e4210374913b376e925e96fdcfa9be6416b/polars_runtime_32-1.40.1-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:992d14cf191dde043d36fbdbc98a65e43fbc7e9a5024cecd45f838ac4988c1ee", size = 54155564, upload-time = "2026-04-22T19:14:47.239Z" },
+    { url = "https://files.pythonhosted.org/packages/06/d9/d091d8fb5cbed5e9536adfed955c4c89987a4cc3b8e73ae4532402b91c74/polars_runtime_32-1.40.1-cp310-abi3-win_amd64.whl", hash = "sha256:f78bb2abd00101cbb23cc0cb068f7e36e081057a15d2ec2dde3dda280709f030", size = 51829755, upload-time = "2026-04-22T19:14:50.85Z" },
+    { url = "https://files.pythonhosted.org/packages/65/ad/b33c3022a394f3eb55c3310597cec615412a8a33880055eee191d154a628/polars_runtime_32-1.40.1-cp310-abi3-win_arm64.whl", hash = "sha256:b5cbfaf6b085b420b4bfcbe24e8f665076d1cccfdb80c0484c02a023ce205537", size = 45822104, upload-time = "2026-04-22T19:14:54.192Z" },
+]
+
+[[package]]
 name = "psutil"
 version = "7.2.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1665,7 +1693,7 @@ requires-dist = [
     { name = "sphinx-simplepdf", specifier = ">=1.6.0" },
     { name = "sphinx-test-reports", specifier = ">=1.3.2" },
     { name = "sphinxcontrib-plantuml", specifier = ">=0.30" },
-    { name = "ubt-sphinx", specifier = "==0.6.1" },
+    { name = "ubt-sphinx", specifier = "==0.7.1" },
 ]
 
 [[package]]
@@ -1957,22 +1985,23 @@ wheels = [
 
 [[package]]
 name = "ubt-runtime"
-version = "0.5.0"
+version = "0.6.0"
 source = { registry = "https://pypi.useblocks.com/" }
 wheels = [
-    { url = "https://pypi.useblocks.com/ubt-runtime/ubt_runtime-0.5.0-cp312-abi3-macosx_11_0_arm64.whl", hash = "sha256:3f23fbf06eedb2532347c46998e0906728c7a623d35f5c7a13ed5c707a863043" },
-    { url = "https://pypi.useblocks.com/ubt-runtime/ubt_runtime-0.5.0-cp312-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:667cdda0559c7b5cafcb5c63c433e8f36d312a5f04e05338effbd25c6ccab81f" },
-    { url = "https://pypi.useblocks.com/ubt-runtime/ubt_runtime-0.5.0-cp312-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8254beef7907583f1f4a4ac8c6dfb235159744f370970e66c222aeeaee2f4ead" },
-    { url = "https://pypi.useblocks.com/ubt-runtime/ubt_runtime-0.5.0-cp312-abi3-win_amd64.whl", hash = "sha256:364a65cbe0f7d2063befe4ef525e98c63768b5ac5ad29151bbac18636d02f1a8" },
+    { url = "https://pypi.useblocks.com/ubt-runtime/ubt_runtime-0.6.0-cp312-abi3-macosx_11_0_arm64.whl", hash = "sha256:a60a8f78c2b1604bc0a014e9ec2f1b6455f0ff11f2a5a6e84a2a35312b44d8ee" },
+    { url = "https://pypi.useblocks.com/ubt-runtime/ubt_runtime-0.6.0-cp312-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e977e554cb23b749c1c33d2882939f135665922617a3afbde672fc39b38e544b" },
+    { url = "https://pypi.useblocks.com/ubt-runtime/ubt_runtime-0.6.0-cp312-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:18abc92ca980daa2eb086bc9220bbd6f9e7fd6e11750dc292a81dcb2fd3100e4" },
+    { url = "https://pypi.useblocks.com/ubt-runtime/ubt_runtime-0.6.0-cp312-abi3-win_amd64.whl", hash = "sha256:65ee6c71333642282c932d126996c009e3d94446aa0a4b52eda7becacb9b9438" },
 ]
 
 [[package]]
 name = "ubt-sphinx"
-version = "0.6.1"
+version = "0.7.1"
 source = { registry = "https://pypi.useblocks.com/" }
 dependencies = [
     { name = "beautifulsoup4" },
     { name = "docutils" },
+    { name = "polars" },
     { name = "rcssmin" },
     { name = "rjsmin" },
     { name = "sphinx" },
@@ -1983,7 +2012,7 @@ dependencies = [
     { name = "ubt-runtime" },
 ]
 wheels = [
-    { url = "https://pypi.useblocks.com/ubt-sphinx/ubt_sphinx-0.6.1-py3-none-any.whl", hash = "sha256:dfbc8c10033dad7bc562c4d2e456716038551a7e3ea34c766f787e08026294f0" },
+    { url = "https://pypi.useblocks.com/ubt-sphinx/ubt_sphinx-0.7.1-py3-none-any.whl", hash = "sha256:65fdba64383e0ea12ea4c3794a0a44af53beb8764dba09f134105b4a5f615b63" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Bump `ubt-sphinx` 0.6.1 → 0.7.1 in `pyproject.toml`, `.readthedocs.yaml`, and `uv.lock` (ubt-runtime is pulled in at 0.5.0 → 0.6.0; `polars` is added as a transitive dep of ubt-sphinx 0.7.1).
- Sphinx 9 upgrade was deferred: `sphinx-codelinks` 1.2.0 (latest published) caps `sphinx<9`, so the resolver rejects sphinx>=9 even though ubt-sphinx 0.7.1 supports it.

## Test plan
- [x] `uv lock` clean
- [x] `uv run sphinx-build -W -b html . _build/html` (in `docs/`) — build succeeded
- [x] `uv run sphinx-build -W -b ubtrace . _build/ubtrace` (in `docs/`) — build succeeded
- [x] CI green