### PR TITLE
feat: Sweep status fields on existing needs and tests

### DIFF
--- a/docs/automotive-adas/swe_1_sw_req_analysis.rst
+++ b/docs/automotive-adas/swe_1_sw_req_analysis.rst
@@ -8,7 +8,7 @@ SWE.1 Software Requirements
 
 .. swreq:: Lane Marking Detection Algorithm
    :id: SWREQ_001
-   :status: open
+   :status: in progress
    :links: ARCH_001, REQ_001
    :author: PETER
    :github: 4
@@ -34,7 +34,7 @@ SWE.1 Software Requirements
 
 .. swreq:: Radar-Based Distance Measurement
    :id: SWREQ_004
-   :status: open
+   :status: closed
    :links: ARCH_002, REQ_003
    :author: ROBERT
 
@@ -42,7 +42,7 @@ SWE.1 Software Requirements
 
 .. swreq:: Speed Control Integration
    :id: SWREQ_005
-   :status: open
+   :status: closed
    :links: ARCH_002, REQ_004
    :author: PETER
 

--- a/docs/automotive-adas/swe_5_sw_integration_tests.rst
+++ b/docs/automotive-adas/swe_5_sw_integration_tests.rst
@@ -52,7 +52,7 @@ This document provides integration test cases for the software architecture, ens
 
 .. test:: Traffic Sign Recognition and Speed Control Integration
    :id: TEST_INT_007
-   :status: passed
+   :status: failed
    :links: SWARCH_007, SWARCH_002
    :author: THOMAS
 

--- a/docs/automotive-adas/sys_1_req_elicitation.rst
+++ b/docs/automotive-adas/sys_1_req_elicitation.rst
@@ -6,7 +6,7 @@ SYS.1 Requirement Elicitation
 
 .. need:: Lane Keeping Assistance
    :id: NEED_001
-   :status: open
+   :status: in progress
    :author: ROBERT
    :jira: 1
 
@@ -15,7 +15,7 @@ SYS.1 Requirement Elicitation
 
 .. need:: Adaptive Cruise Control
    :id: NEED_002
-   :status: open
+   :status: closed
    :author: ROBERT
    :jira: 2
 
@@ -24,7 +24,7 @@ SYS.1 Requirement Elicitation
 
 .. need:: Emergency Braking System
    :id: NEED_003
-   :status: open
+   :status: in progress
    :author: ROBERT
 
    The system shall detect potential collisions and apply the brakes autonomously to
@@ -32,7 +32,7 @@ SYS.1 Requirement Elicitation
 
 .. need:: Pedestrian Detection
    :id: NEED_004
-   :status: open
+   :status: in progress
    :author: ROBERT
 
    The system shall identify pedestrians in the vehicle's path and issue warnings or

--- a/docs/automotive-adas/sys_2_req_analysis.rst
+++ b/docs/automotive-adas/sys_2_req_analysis.rst
@@ -9,7 +9,7 @@ SYS.2 Requirement Analysis
 
 .. req:: Lane Detection Algorithm
    :id: REQ_001
-   :status: open
+   :status: in progress
    :links: NEED_001
    :release: REL_ADAS_2025_6
    :author: PETER
@@ -31,7 +31,7 @@ SYS.2 Requirement Analysis
 
 .. req:: Distance Measurement System
    :id: REQ_003
-   :status: open
+   :status: closed
    :links: NEED_002
    :release: REL_ADAS_2025_12
    :author: PETER
@@ -40,7 +40,7 @@ SYS.2 Requirement Analysis
 
 .. req:: Speed Adjustment Algorithm
    :id: REQ_004
-   :status: open
+   :status: closed
    :links: NEED_002
    :release: REL_ADAS_2025_12
    :author: ROBERT
@@ -49,7 +49,7 @@ SYS.2 Requirement Analysis
 
 .. req:: Collision Detection Module
    :id: REQ_005
-   :status: open
+   :status: in progress
    :links: NEED_003
    :release: REL_ADAS_2025_12
    :author: ROBERT
@@ -67,7 +67,7 @@ SYS.2 Requirement Analysis
 
 .. req:: Pedestrian Recognition System
    :id: REQ_007
-   :status: open
+   :status: in progress
    :links: NEED_004
    :release: REL_ADAS_2025_12
    :author: ROBERT

--- a/docs/automotive-adas/sys_3_sys_arch.rst
+++ b/docs/automotive-adas/sys_3_sys_arch.rst
@@ -9,7 +9,7 @@ SYS.3 Architecture Design
 
 .. arch:: Lane Detection Module
    :id: ARCH_001
-   :status: open
+   :status: in progress
    :links: REQ_001, REQ_002
    :author: ALFRED
 
@@ -36,7 +36,7 @@ SYS.3 Architecture Design
 
 .. arch:: Adaptive Cruise Control System
    :id: ARCH_002
-   :status: open
+   :status: closed
    :links: REQ_003, REQ_004
    :author: ALFRED
 


### PR DESCRIPTION
Move several existing system needs and software requirements through the lifecycle, and flip one previously-passing integration test to a failing state.                                    
                                                                                                                                                                                              
This PR adds no new items. It exists to give the ubTrace version-trend chart visible field churn between releases, including one regression so the chart can show recovery in a later release. 