### PR TITLE
feat: Add automated parking assist v-model trace

### DIFF
--- a/docs/automotive-adas/swe_1_sw_req_analysis.rst
+++ b/docs/automotive-adas/swe_1_sw_req_analysis.rst
@@ -212,3 +212,22 @@ SWE.1 Software Requirements
    Aggregate per-frame eye-state observations into a smoothed drowsiness score and
    emit progressive alerts when the score exceeds calibrated thresholds for the
    required dwell time.
+
+.. swreq:: Parking Slot Recognition
+   :id: SWREQ_026
+   :status: open
+   :links: ARCH_010, REQ_015
+   :author: SARAH
+
+   Implement software to recognize parallel and perpendicular parking slots from
+   fused ultrasonic ranging and surround-view camera input, and rank them by feasibility.
+
+.. swreq:: Park Trajectory Planning
+   :id: SWREQ_027
+   :status: open
+   :links: ARCH_010, REQ_016
+   :author: SARAH
+
+   Plan and follow a smooth park trajectory into the selected slot, respecting
+   clearance margins, maximum speed, and steering rate limits, with abort behavior
+   on detected obstacles.

--- a/docs/automotive-adas/swe_2_sw_arch.rst
+++ b/docs/automotive-adas/swe_2_sw_arch.rst
@@ -261,3 +261,43 @@ SWE.2 Software Architecture
       DrowsinessMonitor --> ScoreAggregator
       DrowsinessMonitor --> AlertEmitter
       @enduml
+
+.. swarch:: Automated Parking Subsystem
+   :id: SWARCH_010
+   :status: open
+   :links: SWREQ_026, SWREQ_027
+   :author: SARAH
+
+   Define the software architecture for the automated parking subsystem, covering slot
+   recognition from fused ultrasonic and camera input, trajectory planning, and
+   actuator command sequencing during the park maneuver.
+
+   .. uml::
+
+      @startuml
+      class ParkingAssist {
+          + detectSlot()
+          + planTrajectory()
+          + executeManeuver()
+      }
+      class UltrasonicSensor {
+          + readClearances()
+      }
+      class SurroundCameraSource {
+          + readSlotImagery()
+      }
+      class SlotDetector {
+          + rankCandidateSlots()
+      }
+      class TrajectoryPlanner {
+          + computeWaypoints()
+      }
+      class ActuatorBridge {
+          + commandSteeringThrottleBrake()
+      }
+      ParkingAssist --> UltrasonicSensor
+      ParkingAssist --> SurroundCameraSource
+      ParkingAssist --> SlotDetector
+      ParkingAssist --> TrajectoryPlanner
+      ParkingAssist --> ActuatorBridge
+      @enduml

--- a/docs/automotive-adas/swe_5_sw_integration_tests.rst
+++ b/docs/automotive-adas/swe_5_sw_integration_tests.rst
@@ -77,3 +77,13 @@ This document provides integration test cases for the software architecture, ens
    Exercise the drowsiness detection subsystem end to end: feed cabin frame sequences
    spanning alert, fatigued, and severely drowsy driver states, and verify progressive
    alerts are raised once the smoothed drowsiness score exceeds the calibrated dwell time.
+
+.. test:: Automated Parking Pipeline Integration
+   :id: TEST_INT_010
+   :status: open
+   :links: SWARCH_010
+   :author: THOMAS
+
+   Exercise the automated parking subsystem end to end: feed synthesized ultrasonic
+   ranges and surround-camera frames for parallel and perpendicular slots, plan the
+   trajectory, and verify actuator commands stay within clearance and rate limits.

--- a/docs/automotive-adas/swe_6_sw_quali_tests.rst
+++ b/docs/automotive-adas/swe_6_sw_quali_tests.rst
@@ -60,3 +60,12 @@ This document provides qualification test cases to validate the fulfillment of s
 
    Qualify the drowsiness detection software by verifying eye-state estimation and
    alert behavior across daytime, low-light, and partially-occluded driver scenarios.
+
+.. test:: Automated Parking Qualification
+   :id: TEST_QUAL_009
+   :status: open
+   :links: SWREQ_026, SWREQ_027
+
+   Qualify the automated parking software by verifying slot recognition and park
+   trajectory execution across parallel and perpendicular slots, mixed obstacle
+   density, and varied surface markings.

--- a/docs/automotive-adas/sys_1_req_elicitation.rst
+++ b/docs/automotive-adas/sys_1_req_elicitation.rst
@@ -63,3 +63,12 @@ SYS.1 Requirement Elicitation
    The system shall observe driver state via the cabin camera and warn the driver,
    and optionally suggest a break, when sustained signs of drowsiness or inattention
    are detected.
+
+.. need:: Automated Parking Assist
+   :id: NEED_008
+   :status: open
+   :author: ROBERT
+
+   The system shall identify suitable parallel and perpendicular parking slots and
+   semi-autonomously steer, accelerate, and brake the vehicle into the selected slot
+   under driver supervision.

--- a/docs/automotive-adas/sys_2_req_analysis.rst
+++ b/docs/automotive-adas/sys_2_req_analysis.rst
@@ -141,3 +141,23 @@ SYS.2 Requirement Analysis
 
    Issue progressive driver alerts and propose a break when the drowsiness score
    exceeds the configured threshold for longer than the calibrated dwell time.
+
+.. req:: Parking Slot Detection
+   :id: REQ_015
+   :status: open
+   :links: NEED_008
+   :release: REL_ADAS_2026_6
+   :author: ROBERT
+
+   Develop functionality to detect parallel and perpendicular parking slots from
+   ultrasonic distance sensors fused with the surround-view camera system.
+
+.. req:: Park Trajectory Execution
+   :id: REQ_016
+   :status: open
+   :links: NEED_008
+   :release: REL_ADAS_2026_6
+   :author: ROBERT
+
+   Plan a feasible park trajectory into the chosen slot and command steering, throttle,
+   and braking actuators to follow it within configured speed and clearance bounds.

--- a/docs/automotive-adas/sys_3_sys_arch.rst
+++ b/docs/automotive-adas/sys_3_sys_arch.rst
@@ -300,3 +300,41 @@ SYS.3 Architecture Design
       DrowsinessMonitor --> DrowsinessScorer
       DrowsinessScorer --> DriverAlertSystem
       @enduml
+
+.. arch:: Automated Parking System
+   :id: ARCH_010
+   :status: open
+   :links: REQ_015, REQ_016
+   :author: ALFRED
+
+   Define the system architecture for automated parking, combining ultrasonic ranging
+   and surround-view camera input for slot detection, a trajectory planner, and the
+   actuator interface that commands steering, throttle, and brake during the park maneuver.
+
+   .. uml::
+
+      @startuml
+      node "Vehicle" {
+          component ParkingAssist {
+              agent detectParkingSlot
+              agent planParkTrajectory
+              agent executeParkManeuver
+          }
+          component UltrasonicArray {
+              agent measureClearances
+          }
+          component SurroundCamera {
+              agent captureSlotImagery
+          }
+          component TrajectoryPlanner {
+              agent computeWaypoints
+          }
+          component VehicleActuators {
+              agent applySteeringThrottleBrake
+          }
+      }
+      UltrasonicArray --> ParkingAssist
+      SurroundCamera --> ParkingAssist
+      ParkingAssist --> TrajectoryPlanner
+      TrajectoryPlanner --> VehicleActuators
+      @enduml

--- a/docs/automotive-adas/sys_4_sys_integation_tests.rst
+++ b/docs/automotive-adas/sys_4_sys_integation_tests.rst
@@ -69,3 +69,12 @@ SYS.3 function as intended.
    Validate the drowsiness detection architecture by exercising cabin camera capture,
    eye-state estimation, scoring, and alert routing across representative driver
    states from alert through severely drowsy.
+
+.. test:: Automated Parking Validation
+   :id: TEST_SYS_INT_010
+   :status: open
+   :links: ARCH_010
+
+   Validate the automated parking architecture by exercising slot detection from
+   ultrasonic and camera input, trajectory planning, and actuator command sequencing
+   across parallel and perpendicular slot scenarios.

--- a/docs/automotive-adas/sys_5_sys_quali_test.rst
+++ b/docs/automotive-adas/sys_5_sys_quali_test.rst
@@ -61,6 +61,15 @@ This document provides verification test cases to ensure the requirements define
    Verify the system fulfills the driver eye state estimation and drowsiness alert
    requirements across daytime, low-light, and sunglasses-wearing driver scenarios.
 
+.. test:: Automated Parking Verification
+   :id: TEST_SYS_QUAL_009
+   :status: open
+   :links: REQ_015, REQ_016
+
+   Verify the system fulfills slot detection and park trajectory execution
+   requirements across parallel and perpendicular slot scenarios with mixed
+   surrounding obstacles.
+
 
 SYS.5 Qualification Test Results
 --------------------------------

--- a/src/automotive_adas.py
+++ b/src/automotive_adas.py
@@ -251,3 +251,52 @@ class DrowsinessMonitor:
         observation = self.estimate_eye_state(frame)
         self._score = 0.7 * self._score + 0.3 * observation
         return self._score >= self.DROWSY_THRESHOLD
+
+
+class ParkingAssist:
+    """
+    .. impl:: Automated Parking Assist
+       :id: IMPL_022
+       :status: open
+       :links: SWREQ_026, SWARCH_010
+
+       Detects available parking slots and plans a park trajectory.
+    """
+
+    MIN_PARALLEL_LENGTH = 5.0
+    MIN_PERPENDICULAR_WIDTH = 2.4
+
+    def detect_slot(self, ultrasonic_readings, slot_kind):
+        """
+        .. impl:: Parking Slot Recognition
+           :id: IMPL_023
+           :status: open
+           :links: SWREQ_026, SWARCH_010
+
+           Returns the first slot whose dimensions clear the configured minimum.
+        """
+        threshold = (
+            self.MIN_PARALLEL_LENGTH
+            if slot_kind == "parallel"
+            else self.MIN_PERPENDICULAR_WIDTH
+        )
+        for index, reading in enumerate(ultrasonic_readings or []):
+            if reading >= threshold:
+                return {"index": index, "kind": slot_kind, "size": reading}
+        return None
+
+    def plan_trajectory(self, slot):
+        """
+        .. impl:: Park Trajectory Planning
+           :id: IMPL_024
+           :status: open
+           :links: SWREQ_027, SWARCH_010
+
+           Returns a list of waypoints leading into the chosen slot.
+        """
+        if slot is None:
+            return []
+        kind = slot.get("kind", "perpendicular")
+        if kind == "parallel":
+            return ["align", "reverse_into_slot", "straighten"]
+        return ["align", "forward_into_slot"]

--- a/src/automotive_adas_tests.py
+++ b/src/automotive_adas_tests.py
@@ -7,6 +7,7 @@ from automotive_adas import (
    TrafficSignRecognition,
     BlindSpotMonitor,
     DrowsinessMonitor,
+    ParkingAssist,
 )
 
 
@@ -245,6 +246,44 @@ class TestDrowsinessMonitor(unittest.TestCase):
         dm = DrowsinessMonitor()
         for _ in range(20):
             self.assertFalse(dm.update({"eye_aspect_ratio": 0.35}))
+
+
+class TestParkingAssist(unittest.TestCase):
+    """
+    .. test:: Parking Assist Tests
+       :id: TEST_022
+       :status: open
+       :links: SWREQ_026, SWREQ_027, SWARCH_010
+       :author: THOMAS
+
+       Unit tests for parking assist functionalities.
+    """
+
+    def test_detects_first_parallel_slot_meeting_size(self):
+        """
+        .. test:: Parking Slot Detection Test
+           :id: TEST_023
+           :status: open
+           :links: SWREQ_026, SWARCH_010
+           :author: THOMAS
+        """
+        pa = ParkingAssist()
+        slot = pa.detect_slot([3.0, 4.5, 6.0, 4.0], slot_kind="parallel")
+        self.assertEqual(slot["index"], 2)
+        self.assertEqual(slot["kind"], "parallel")
+
+    def test_plan_trajectory_varies_by_slot_kind(self):
+        """
+        .. test:: Park Trajectory Planning Test
+           :id: TEST_024
+           :status: open
+           :links: SWREQ_027, SWARCH_010
+           :author: THOMAS
+        """
+        pa = ParkingAssist()
+        self.assertIn("reverse_into_slot", pa.plan_trajectory({"kind": "parallel"}))
+        self.assertIn("forward_into_slot", pa.plan_trajectory({"kind": "perpendicular"}))
+        self.assertEqual(pa.plan_trajectory(None), [])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Add a new V-model trace for automated parking assist: ultrasonic plus surround-camera slot detection, trajectory planning, and actuator command sequencing. Mirrors the structure of the blind spot and drowsiness traces.

Stacked on top of #54 (drowsiness). Base is feat/driver-drowsiness-detection; GitHub will retarget to main once #52 and #54 merge in order.

Final PR in the workshop demo prep series for 2026-05-06.