### PR TITLE
feat: Add driver drowsiness detection v-model trace

### DIFF
--- a/docs/automotive-adas/swe_1_sw_req_analysis.rst
+++ b/docs/automotive-adas/swe_1_sw_req_analysis.rst
@@ -193,3 +193,22 @@ SWE.1 Software Requirements
 
    Implement arbitration logic that activates the blind spot warning only when the turn
    signal points toward an occupied zone, suppressing nuisance alerts otherwise.
+
+.. swreq:: Eye Aspect Ratio Estimation
+   :id: SWREQ_024
+   :status: open
+   :links: ARCH_009, REQ_013
+   :author: STEVEN
+
+   Implement software to estimate per-frame eye-aspect ratio and gaze direction from
+   cabin camera input under varying lighting conditions.
+
+.. swreq:: Drowsiness Score Aggregation
+   :id: SWREQ_025
+   :status: open
+   :links: ARCH_009, REQ_014
+   :author: STEVEN
+
+   Aggregate per-frame eye-state observations into a smoothed drowsiness score and
+   emit progressive alerts when the score exceeds calibrated thresholds for the
+   required dwell time.

--- a/docs/automotive-adas/swe_2_sw_arch.rst
+++ b/docs/automotive-adas/swe_2_sw_arch.rst
@@ -225,3 +225,39 @@ SWE.2 Software Architecture
       BlindSpotMonitor --> TurnSignalArbiter
       BlindSpotMonitor --> WarningEmitter
       @enduml
+
+.. swarch:: Driver Drowsiness Subsystem
+   :id: SWARCH_009
+   :status: open
+   :links: SWREQ_024, SWREQ_025
+   :author: STEVEN
+
+   Define the software architecture for the driver drowsiness subsystem, covering
+   cabin camera capture, per-frame eye-state estimation, drowsiness score aggregation,
+   and emission of progressive driver alerts.
+
+   .. uml::
+
+      @startuml
+      class DrowsinessMonitor {
+          + estimateEyeState()
+          + updateDrowsinessScore()
+          + emitAlert()
+      }
+      class CabinFrameSource {
+          + readFrame()
+      }
+      class EyeStateClassifier {
+          + classifyEyeAspectRatio()
+      }
+      class ScoreAggregator {
+          + aggregateScore()
+      }
+      class AlertEmitter {
+          + raiseDrowsinessAlert()
+      }
+      DrowsinessMonitor --> CabinFrameSource
+      DrowsinessMonitor --> EyeStateClassifier
+      DrowsinessMonitor --> ScoreAggregator
+      DrowsinessMonitor --> AlertEmitter
+      @enduml

--- a/docs/automotive-adas/swe_5_sw_integration_tests.rst
+++ b/docs/automotive-adas/swe_5_sw_integration_tests.rst
@@ -67,3 +67,13 @@ This document provides integration test cases for the software architecture, ens
    Exercise the blind spot monitoring subsystem end to end: feed synthesized radar and
    side-camera streams plus turn-signal events, and verify the warning emitter fires
    only when an occupied zone aligns with the indicated lane change.
+
+.. test:: Drowsiness Detection Pipeline Integration
+   :id: TEST_INT_009
+   :status: open
+   :links: SWARCH_009
+   :author: THOMAS
+
+   Exercise the drowsiness detection subsystem end to end: feed cabin frame sequences
+   spanning alert, fatigued, and severely drowsy driver states, and verify progressive
+   alerts are raised once the smoothed drowsiness score exceeds the calibrated dwell time.

--- a/docs/automotive-adas/swe_6_sw_quali_tests.rst
+++ b/docs/automotive-adas/swe_6_sw_quali_tests.rst
@@ -52,3 +52,11 @@ This document provides qualification test cases to validate the fulfillment of s
 
    Qualify the blind spot monitoring software by verifying zone occupancy detection and
    lane change warning behavior across mixed traffic, weather, and lighting scenarios.
+
+.. test:: Driver Drowsiness Qualification
+   :id: TEST_QUAL_008
+   :status: open
+   :links: SWREQ_024, SWREQ_025
+
+   Qualify the drowsiness detection software by verifying eye-state estimation and
+   alert behavior across daytime, low-light, and partially-occluded driver scenarios.

--- a/docs/automotive-adas/sys_1_req_elicitation.rst
+++ b/docs/automotive-adas/sys_1_req_elicitation.rst
@@ -54,3 +54,12 @@ SYS.1 Requirement Elicitation
    The system shall monitor zones to the rear and sides of the vehicle that are not
    directly visible to the driver, and warn the driver when another road user enters
    those zones while a lane change is intended.
+
+.. need:: Driver Drowsiness Detection
+   :id: NEED_007
+   :status: open
+   :author: ROBERT
+
+   The system shall observe driver state via the cabin camera and warn the driver,
+   and optionally suggest a break, when sustained signs of drowsiness or inattention
+   are detected.

--- a/docs/automotive-adas/sys_2_req_analysis.rst
+++ b/docs/automotive-adas/sys_2_req_analysis.rst
@@ -121,3 +121,23 @@ SYS.2 Requirement Analysis
 
    Issue a driver warning when the turn signal is engaged toward a blind spot zone
    that is currently occupied by another road user.
+
+.. req:: Driver Eye State Estimation
+   :id: REQ_013
+   :status: open
+   :links: NEED_007
+   :release: REL_ADAS_2026_6
+   :author: ROBERT
+
+   Develop functionality to estimate driver eye-aspect ratio and gaze direction from
+   the cabin camera at the cadence required for drowsiness scoring.
+
+.. req:: Drowsiness Alert and Break Suggestion
+   :id: REQ_014
+   :status: open
+   :links: NEED_007
+   :release: REL_ADAS_2026_6
+   :author: ROBERT
+
+   Issue progressive driver alerts and propose a break when the drowsiness score
+   exceeds the configured threshold for longer than the calibrated dwell time.

--- a/docs/automotive-adas/sys_3_sys_arch.rst
+++ b/docs/automotive-adas/sys_3_sys_arch.rst
@@ -266,3 +266,37 @@ SYS.3 Architecture Design
       TurnSignalSensor --> BlindSpotMonitor
       BlindSpotMonitor --> DriverAlertSystem
       @enduml
+
+.. arch:: Driver Drowsiness Detection System
+   :id: ARCH_009
+   :status: open
+   :links: REQ_013, REQ_014
+   :author: ALFRED
+
+   Define the system architecture for driver drowsiness detection, combining cabin
+   camera capture with an eye-state estimator and a drowsiness scorer that emits
+   progressive alerts via the existing driver alert system.
+
+   .. uml::
+
+      @startuml
+      node "Vehicle" {
+          component DrowsinessMonitor {
+              agent estimateEyeState
+              agent scoreDrowsiness
+          }
+          component CabinCamera {
+              agent captureDriverFace
+          }
+          component DrowsinessScorer {
+              agent updateScore
+          }
+          component DriverAlertSystem {
+              agent issueDrowsinessAlert
+              agent suggestBreak
+          }
+      }
+      CabinCamera --> DrowsinessMonitor
+      DrowsinessMonitor --> DrowsinessScorer
+      DrowsinessScorer --> DriverAlertSystem
+      @enduml

--- a/docs/automotive-adas/sys_4_sys_integation_tests.rst
+++ b/docs/automotive-adas/sys_4_sys_integation_tests.rst
@@ -60,3 +60,12 @@ SYS.3 function as intended.
    Validate the blind spot monitoring architecture by exercising radar/camera sensor
    fusion against turn signal intent and confirming alerts are routed to the driver
    alert system within the required latency budget.
+
+.. test:: Driver Drowsiness Detection Validation
+   :id: TEST_SYS_INT_009
+   :status: open
+   :links: ARCH_009
+
+   Validate the drowsiness detection architecture by exercising cabin camera capture,
+   eye-state estimation, scoring, and alert routing across representative driver
+   states from alert through severely drowsy.

--- a/docs/automotive-adas/sys_5_sys_quali_test.rst
+++ b/docs/automotive-adas/sys_5_sys_quali_test.rst
@@ -53,6 +53,14 @@ This document provides verification test cases to ensure the requirements define
    Verify the system fulfills blind spot zone detection and lane change hazard
    warning requirements across representative urban and highway scenarios.
 
+.. test:: Driver Drowsiness Detection Verification
+   :id: TEST_SYS_QUAL_008
+   :status: open
+   :links: REQ_013, REQ_014
+
+   Verify the system fulfills the driver eye state estimation and drowsiness alert
+   requirements across daytime, low-light, and sunglasses-wearing driver scenarios.
+
 
 SYS.5 Qualification Test Results
 --------------------------------

--- a/src/automotive_adas.py
+++ b/src/automotive_adas.py
@@ -206,3 +206,48 @@ class BlindSpotMonitor:
         if turn_signal not in ("left", "right"):
             return False
         return bool(zones.get(turn_signal))
+
+
+class DrowsinessMonitor:
+    """
+    .. impl:: Driver Drowsiness Monitor
+       :id: IMPL_019
+       :status: open
+       :links: SWREQ_024, SWARCH_009
+
+       Aggregates eye-state observations from the cabin camera into a drowsiness score.
+    """
+
+    DROWSY_THRESHOLD = 0.6
+
+    def __init__(self):
+        self._score = 0.0
+
+    def estimate_eye_state(self, frame):
+        """
+        .. impl:: Eye Aspect Ratio Estimation
+           :id: IMPL_020
+           :status: open
+           :links: SWREQ_024, SWARCH_009
+
+           Returns an eye-closed indicator derived from the input frame.
+        """
+        if isinstance(frame, dict):
+            ratio = frame.get("eye_aspect_ratio")
+            if ratio is None:
+                return 0.0
+            return 1.0 if ratio < 0.2 else 0.0
+        return 0.0
+
+    def update(self, frame):
+        """
+        .. impl:: Drowsiness Score Aggregation
+           :id: IMPL_021
+           :status: open
+           :links: SWREQ_025, SWARCH_009
+
+           Updates the smoothed drowsiness score and reports whether an alert should fire.
+        """
+        observation = self.estimate_eye_state(frame)
+        self._score = 0.7 * self._score + 0.3 * observation
+        return self._score >= self.DROWSY_THRESHOLD

--- a/src/automotive_adas_tests.py
+++ b/src/automotive_adas_tests.py
@@ -6,6 +6,7 @@ from automotive_adas import (
     PedestrianDetection,
    TrafficSignRecognition,
     BlindSpotMonitor,
+    DrowsinessMonitor,
 )
 
 
@@ -204,6 +205,46 @@ class TestBlindSpotMonitor(unittest.TestCase):
         self.assertTrue(bsm.evaluate_lane_change(zones, turn_signal="left"))
         self.assertFalse(bsm.evaluate_lane_change(zones, turn_signal="right"))
         self.assertFalse(bsm.evaluate_lane_change(zones, turn_signal=None))
+
+
+class TestDrowsinessMonitor(unittest.TestCase):
+    """
+    .. test:: Drowsiness Monitor Tests
+       :id: TEST_019
+       :status: open
+       :links: SWREQ_024, SWREQ_025, SWARCH_009
+       :author: THOMAS
+
+       Unit tests for driver drowsiness monitor functionalities.
+    """
+
+    def test_alert_fires_when_eyes_closed_for_long_enough(self):
+        """
+        .. test:: Drowsiness Alert Trigger Test
+           :id: TEST_020
+           :status: open
+           :links: SWREQ_025, SWARCH_009
+           :author: THOMAS
+        """
+        dm = DrowsinessMonitor()
+        alert = False
+        for _ in range(20):
+            alert = dm.update({"eye_aspect_ratio": 0.1})
+            if alert:
+                break
+        self.assertTrue(alert)
+
+    def test_alert_quiet_for_alert_driver(self):
+        """
+        .. test:: Drowsiness No Alert Test
+           :id: TEST_021
+           :status: open
+           :links: SWREQ_025, SWARCH_009
+           :author: THOMAS
+        """
+        dm = DrowsinessMonitor()
+        for _ in range(20):
+            self.assertFalse(dm.update({"eye_aspect_ratio": 0.35}))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Add a new V-model trace for driver drowsiness detection: cabin camera capture, eye-state estimation, drowsiness score aggregation, and progressive driver alerts. Mirrors the structure of the blind spot monitoring trace.

Replaces #54 (closed when its stacked base branch feat/blind-spot-monitoring was deleted after #52 merged). Branch was rebased onto main; only the drowsiness commit remains.

Part of the workshop demo prep for 2026-05-06; v0.1.5 (parking assist) follows.