### PR TITLE
Update ubt-sphinx from 0.7.1 to 0.8.0

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -24,7 +24,7 @@ build:
     post_create_environment:
       # ubt-sphinx is only available on the private pypi.useblocks.com index, not on PyPI.
       # RTD's pip install uses PyPI by default, so we pre-install it here before the main install runs.
-      - pip install --extra-index-url https://pypi.useblocks.com/ "ubt-sphinx==0.7.1"
+      - pip install --extra-index-url https://pypi.useblocks.com/ "ubt-sphinx==0.8.0"
 # Build documentation in the "docs/" directory with Sphinx
 sphinx:
   configuration: docs/conf.py

--- a/docs/ubproject.toml
+++ b/docs/ubproject.toml
@@ -680,11 +680,12 @@ remote_url_pattern = "https://github.com/useblocks/sphinx-needs-demo/blob/{commi
 [codelinks.projects.coffee_machine.source_discover]
 src_dir = "../crates"  # Relative path to Rust source
 gitignore = true
-comment_type = "rust"
+comment_type = "cpp"
 
 [codelinks.projects.coffee_machine.analyse]
 get_need_id_refs = false      # Don't extract need ID references (just for simple linking)
 get_oneline_needs = true      # Extract oneline need definitions from code
+get_rst = true
 
 [codelinks.projects.coffee_machine.analyse.oneline_comment_style]
 start_sequence = "@ "         # Start sequence: "// @ "

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "sphinx-test-reports>=1.3.2",  # pin as RTD consumes this file, not uv.lock
     "furo>=2024.8.6",
     "sphinx-preview>=0.1.2",
-    "ubt-sphinx==0.7.1"
+    "ubt-sphinx==0.8.0"
 ]
 readme = "README.md"
 requires-python = ">= 3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -1693,7 +1693,7 @@ requires-dist = [
     { name = "sphinx-simplepdf", specifier = ">=1.6.0" },
     { name = "sphinx-test-reports", specifier = ">=1.3.2" },
     { name = "sphinxcontrib-plantuml", specifier = ">=0.30" },
-    { name = "ubt-sphinx", specifier = "==0.7.1" },
+    { name = "ubt-sphinx", specifier = "==0.8.0" },
 ]
 
 [[package]]
@@ -1996,7 +1996,7 @@ wheels = [
 
 [[package]]
 name = "ubt-sphinx"
-version = "0.7.1"
+version = "0.8.0"
 source = { registry = "https://pypi.useblocks.com/" }
 dependencies = [
     { name = "beautifulsoup4" },
@@ -2012,7 +2012,7 @@ dependencies = [
     { name = "ubt-runtime" },
 ]
 wheels = [
-    { url = "https://pypi.useblocks.com/ubt-sphinx/ubt_sphinx-0.7.1-py3-none-any.whl", hash = "sha256:65fdba64383e0ea12ea4c3794a0a44af53beb8764dba09f134105b4a5f615b63" },
+    { url = "https://pypi.useblocks.com/ubt-sphinx/ubt_sphinx-0.8.0-py3-none-any.whl", hash = "sha256:9bee86ea955f615515a998352c5622cc9bb60a55fa21785c120ddbcc9dc6bcff" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Bumps `ubt-sphinx` from 0.7.1 → 0.8.0 in `pyproject.toml`, the RTD `post_create_environment` install command, and `uv.lock`.
- Resolves a pre-existing merge-conflict block in `docs/ubproject.toml` (under `[codelinks.projects.coffee_machine.analyse]`) by keeping `get_rst = true`. Without this, `sphinx-build` fails with a `KeyError: 'coffee_machine'` from `sphinx_codelinks.src_trace`, so it was needed to verify the bump.

## Test plan
- [x] `uv lock` resolves cleanly (`ubt-sphinx v0.7.1 -> v0.8.0`, 108 packages)
- [x] `uv sync` installs `ubt-sphinx==0.8.0` and `ubt-runtime==0.6.0`
- [x] `sphinx-build -W --keep-going -b ubtrace docs docs/_build/ubtrace` → **build succeeded**, `needs.json` and `ubt_sphinx_structured_rst_data.json` produced, minification 30/30 OK, `source_meta` sniffed GitHub correctly
- [ ] RTD build passes on the PR preview